### PR TITLE
feat: add trivy misconfig, secret, license dtos

### DIFF
--- a/adapter/src/test/resources/trivy-result-v2.json
+++ b/adapter/src/test/resources/trivy-result-v2.json
@@ -184,6 +184,371 @@
           "LastModifiedDate": "2024-01-18T13:48:07.553Z"
         }
       ]
+    },
+    {
+      "Target": "app/Dockerfile",
+      "Class": "config",
+      "Type": "dockerfile",
+      "MisconfSummary": {
+        "Successes": 25,
+        "Failures": 3,
+        "Exceptions": 0
+      },
+      "Misconfigurations": [
+        {
+          "Type": "Dockerfile Security Check",
+          "ID": "DS002",
+          "AVDID": "AVD-DS-0002",
+          "Title": "Image user should not be 'root'",
+          "Description": "Running containers with 'root' user can lead to a container escape situation. It is a best practice to run containers as non-root users, which can be done by adding a 'USER' statement to the Dockerfile.",
+          "Message": "Specify at least 1 USER command in Dockerfile with non-root user as argument",
+          "Namespace": "builtin.dockerfile.DS002",
+          "Query": "data.builtin.dockerfile.DS002.deny",
+          "Resolution": "Add 'USER \u003cnon root user name\u003e' line to the Dockerfile",
+          "Severity": "HIGH",
+          "PrimaryURL": "https://avd.aquasec.com/misconfig/ds002",
+          "References": [
+            "https://docs.docker.com/develop/develop-images/dockerfile_best-practices/",
+            "https://avd.aquasec.com/misconfig/ds002"
+          ],
+          "Status": "FAIL",
+          "Layer": {
+            "Digest": "sha256:xxxx",
+            "DiffID": "sha256:xxxx"
+          },
+          "CauseMetadata": {
+            "Provider": "Dockerfile",
+            "Service": "general",
+            "Code": {
+              "Lines": null
+            }
+          }
+        },
+        {
+          "Type": "Dockerfile Security Check",
+          "ID": "DS005",
+          "AVDID": "AVD-DS-0005",
+          "Title": "ADD instead of COPY",
+          "Description": "You should use COPY instead of ADD unless you want to extract a tar file. Note that an ADD command will extract a tar file, which adds the risk of Zip-based vulnerabilities. Accordingly, it is advised to use a COPY command, which does not extract tar files.",
+          "Message": "Consider using 'COPY . /app' command instead of 'ADD . /app'",
+          "Namespace": "builtin.dockerfile.DS005",
+          "Query": "data.builtin.dockerfile.DS005.deny",
+          "Resolution": "Use COPY instead of ADD",
+          "Severity": "LOW",
+          "PrimaryURL": "https://avd.aquasec.com/misconfig/ds005",
+          "References": [
+            "https://docs.docker.com/engine/reference/builder/#add",
+            "https://avd.aquasec.com/misconfig/ds005"
+          ],
+          "Status": "FAIL",
+          "Layer": {
+            "Digest": "sha256:xxxx",
+            "DiffID": "sha256:xxxx"
+          },
+          "CauseMetadata": {
+            "Provider": "Dockerfile",
+            "Service": "general",
+            "StartLine": 21,
+            "EndLine": 21,
+            "Code": {
+              "Lines": [
+                {
+                  "Number": 21,
+                  "Content": "ADD . /app",
+                  "IsCause": true,
+                  "Annotation": "",
+                  "Truncated": false,
+                  "Highlighted": "\u001b[38;5;64mADD\u001b[0m . /app",
+                  "FirstCause": true,
+                  "LastCause": true
+                }
+              ]
+            }
+          }
+        },
+        {
+          "Type": "Dockerfile Security Check",
+          "ID": "DS026",
+          "AVDID": "AVD-DS-0026",
+          "Title": "No HEALTHCHECK defined",
+          "Description": "You should add HEALTHCHECK instruction in your docker container images to perform the health check on running containers.",
+          "Message": "Add HEALTHCHECK instruction in your Dockerfile",
+          "Namespace": "builtin.dockerfile.DS026",
+          "Query": "data.builtin.dockerfile.DS026.deny",
+          "Resolution": "Add HEALTHCHECK instruction in Dockerfile",
+          "Severity": "LOW",
+          "PrimaryURL": "https://avd.aquasec.com/misconfig/ds026",
+          "References": [
+            "https://blog.aquasec.com/docker-security-best-practices",
+            "https://avd.aquasec.com/misconfig/ds026"
+          ],
+          "Status": "FAIL",
+          "Layer": {
+            "Digest": "sha256:xxxx",
+            "DiffID": "sha256:xxxx"
+          },
+          "CauseMetadata": {
+            "Provider": "Dockerfile",
+            "Service": "general",
+            "Code": {
+              "Lines": null
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Target": "/app/certs/secret.sh",
+      "Class": "secret",
+      "Secrets": [
+        {
+          "RuleID": "gitlab-pat",
+          "Category": "GitLab",
+          "Severity": "CRITICAL",
+          "Title": "GitLab Personal Access Token",
+          "StartLine": 4,
+          "EndLine": 4,
+          "Code": {
+            "Lines": [
+              {
+                "Number": 2,
+                "Content": "export COMPOSE_PROJECT_NAME=something",
+                "IsCause": false,
+                "Annotation": "",
+                "Truncated": false,
+                "Highlighted": "export COMPOSE_PROJECT_NAME=something",
+                "FirstCause": false,
+                "LastCause": false
+              },
+              {
+                "Number": 3,
+                "Content": "export SECRET_USER=something",
+                "IsCause": false,
+                "Annotation": "",
+                "Truncated": false,
+                "Highlighted": "export SECRET_USER=something",
+                "FirstCause": false,
+                "LastCause": false
+              },
+              {
+                "Number": 4,
+                "Content": "export SECRET_APIKEY=**************************",
+                "IsCause": true,
+                "Annotation": "",
+                "Truncated": false,
+                "Highlighted": "export SECRET_APIKEY=**************************",
+                "FirstCause": true,
+                "LastCause": true
+              },
+              {
+                "Number": 5,
+                "Content": "export SOME_PATH=tools/something/something-container.sh",
+                "IsCause": false,
+                "Annotation": "",
+                "Truncated": false,
+                "Highlighted": "export SOME_PATH=tools/something/something-container.sh",
+                "FirstCause": false,
+                "LastCause": false
+              }
+            ]
+          },
+          "Match": "export SECRET_APIKEY=**************************",
+          "Layer": {
+            "Digest": "sha256:xxxx",
+            "DiffID": "sha256:xxxx",
+            "CreatedBy": "ADD . /app # buildkit"
+          }
+        },
+        {
+          "RuleID": "gitlab-pat",
+          "Category": "GitLab",
+          "Severity": "CRITICAL",
+          "Title": "GitLab Personal Access Token",
+          "StartLine": 7,
+          "EndLine": 7,
+          "Code": {
+            "Lines": [
+              {
+                "Number": 5,
+                "Content": "export SOME_PATH=tools/something/something.sh",
+                "IsCause": false,
+                "Annotation": "",
+                "Truncated": false,
+                "Highlighted": "export SOME_PATH=tools/something/something.sh",
+                "FirstCause": false,
+                "LastCause": false
+              },
+              {
+                "Number": 6,
+                "Content": "export USER=something",
+                "IsCause": false,
+                "Annotation": "",
+                "Truncated": false,
+                "Highlighted": "export USER=something",
+                "FirstCause": false,
+                "LastCause": false
+              },
+              {
+                "Number": 7,
+                "Content": "export APIKEY=**************************",
+                "IsCause": true,
+                "Annotation": "",
+                "Truncated": false,
+                "Highlighted": "export APIKEY=**************************",
+                "FirstCause": true,
+                "LastCause": true
+              },
+              {
+                "Number": 8,
+                "Content": "export CONFIG=.config/",
+                "IsCause": false,
+                "Annotation": "",
+                "Truncated": false,
+                "Highlighted": "export CONFIG=.config/",
+                "FirstCause": false,
+                "LastCause": false
+              }
+            ]
+          },
+          "Match": "export APIKEY=**************************",
+          "Layer": {
+            "Digest": "sha256:xxxx",
+            "DiffID": "sha256:xxxx",
+            "CreatedBy": "ADD . /app # buildkit"
+          }
+        },
+        {
+          "RuleID": "gitlab-pat",
+          "Category": "GitLab",
+          "Severity": "CRITICAL",
+          "Title": "GitLab Personal Access Token",
+          "StartLine": 24,
+          "EndLine": 24,
+          "Code": {
+            "Lines": [
+              {
+                "Number": 22,
+                "Content": "export host=127.0.0.1",
+                "IsCause": false,
+                "Annotation": "",
+                "Truncated": false,
+                "Highlighted": "export host=127.0.0.1",
+                "FirstCause": false,
+                "LastCause": false
+              },
+              {
+                "Number": 23,
+                "Content": "export USER=xxxxxx",
+                "IsCause": false,
+                "Annotation": "",
+                "Truncated": false,
+                "Highlighted": "export USER=xxxxxx",
+                "FirstCause": false,
+                "LastCause": false
+              },
+              {
+                "Number": 24,
+                "Content": "export APIKEY=**************************",
+                "IsCause": true,
+                "Annotation": "",
+                "Truncated": false,
+                "Highlighted": "export APIKEY=**************************",
+                "FirstCause": true,
+                "LastCause": true
+              },
+              {
+                "Number": 25,
+                "Content": "export APIKEY=**************************",
+                "IsCause": false,
+                "Annotation": "",
+                "Truncated": false,
+                "Highlighted": "export APIKEY=**************************",
+                "FirstCause": false,
+                "LastCause": false
+              }
+            ]
+          },
+          "Match": "export APIKEY=**************************",
+          "Layer": {
+            "Digest": "sha256:xxxx",
+            "DiffID": "sha256:xxxx",
+            "CreatedBy": "ADD . /app # buildkit"
+          }
+        },
+        {
+          "RuleID": "gitlab-pat",
+          "Category": "GitLab",
+          "Severity": "CRITICAL",
+          "Title": "GitLab Personal Access Token",
+          "StartLine": 25,
+          "EndLine": 25,
+          "Code": {
+            "Lines": [
+              {
+                "Number": 23,
+                "Content": "export USER=something",
+                "IsCause": false,
+                "Annotation": "",
+                "Truncated": false,
+                "Highlighted": "export USER=something",
+                "FirstCause": false,
+                "LastCause": false
+              },
+              {
+                "Number": 24,
+                "Content": "export APIKEY=**************************",
+                "IsCause": false,
+                "Annotation": "",
+                "Truncated": false,
+                "Highlighted": "export APIKEY=**************************",
+                "FirstCause": false,
+                "LastCause": false
+              },
+              {
+                "Number": 25,
+                "Content": "export APIKEY=**************************",
+                "IsCause": true,
+                "Annotation": "",
+                "Truncated": false,
+                "Highlighted": "export APIKEY=**************************",
+                "FirstCause": true,
+                "LastCause": true
+              },
+              {
+                "Number": 26,
+                "Content": "",
+                "IsCause": false,
+                "Annotation": "",
+                "Truncated": false,
+                "FirstCause": false,
+                "LastCause": false
+              }
+            ]
+          },
+          "Match": "export APIKEY=**************************",
+          "Layer": {
+            "Digest": "sha256:xxxx",
+            "DiffID": "sha256:xxxx",
+            "CreatedBy": "ADD . /app # buildkit"
+          }
+        }
+      ]
+    },
+    {
+      "Target": "OS Packages",
+      "Class": "license",
+      "Licenses": [
+        {
+          "Severity": "HIGH",
+          "Category": "restricted",
+          "PkgName": "adduser",
+          "FilePath": "",
+          "Name": "GPL-2.0-or-later",
+          "Text": "",
+          "Confidence": 1,
+          "Link": ""
+        }
+      ]
     }
   ]
 }

--- a/model/src/main/kotlin/de/fraunhofer/iem/spha/model/adapter/trivy/TrivyDto.kt
+++ b/model/src/main/kotlin/de/fraunhofer/iem/spha/model/adapter/trivy/TrivyDto.kt
@@ -29,7 +29,10 @@ data class TrivyDtoV2(
 
 @Serializable
 data class Result(
-    @SerialName("Vulnerabilities") val vulnerabilities: List<TrivyVulnerabilityDto> = listOf()
+    @SerialName("Vulnerabilities") val vulnerabilities: List<TrivyVulnerabilityDto> = listOf(),
+    @SerialName("Licenses") val licenses: List<TrivyLicenseDto> = listOf(),
+    @SerialName("Misconfigurations") val misconfigurations: List<TrivyMisconfigDto> = listOf(),
+    @SerialName("Secrets") val secrets: List<TrivySecretDto> = listOf(),
 )
 
 @Serializable
@@ -55,4 +58,38 @@ data class TrivyVulnerabilityDto(
 data class CVSSData(
     @SerialName("V2Score") val v2Score: Double?,
     @SerialName("V3Score") val v3Score: Double?,
+)
+
+@Serializable
+data class TrivyLicenseDto(
+    // License are classified using the Google License Classification:
+    /**
+     * | Classification | Severity |
+     * |----------------|----------|
+     * | Forbidden      | CRITICAL |
+     * | Restricted     | HIGH     |
+     * | Reciprocal     | MEDIUM   |
+     * | Notice         | LOW      |
+     * | Permissive     | LOW      |
+     * | Unencumbered   | LOW      |
+     * | Unknown        | UNKNOWN  |
+     */
+    @SerialName("Severity") val severity: String,
+    @SerialName("Category") val category: String,
+    @SerialName("PkgName") val pkgName: String,
+    @SerialName("Name") val name: String,
+)
+
+@Serializable
+data class TrivyMisconfigDto(
+    @SerialName("Severity") val severity: String,
+    @SerialName("ID") val id: String,
+    @SerialName("Title") val title: String,
+)
+
+@Serializable
+data class TrivySecretDto(
+    @SerialName("Severity") val severity: String,
+    @SerialName("Category") val category: String,
+    @SerialName("Title") val title: String,
 )


### PR DESCRIPTION
This PR adds the DTOs needed for [misconfigurations](https://trivy.dev/v0.57/docs/scanner/misconfiguration/), [licenses](https://trivy.dev/v0.57/docs/scanner/license/), and [secrets](https://trivy.dev/v0.57/docs/scanner/secret/) scans. It is needed so that the pod manager can send a complete container scan from Trivy.