### PR TITLE
feat!: kpiId type changed from enum to string

### DIFF
--- a/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/kpis/cve/CveAdapter.kt
+++ b/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/kpis/cve/CveAdapter.kt
@@ -36,7 +36,7 @@ object CveAdapter {
         return data.map {
             return@map if (isValid(it)) {
                 AdapterResult.Success.Kpi(
-                    RawValueKpi(kind = kpiId, score = 100 - (it.severity * 10).toInt())
+                    RawValueKpi(kpiId = kpiId.name, score = 100 - (it.severity * 10).toInt())
                 )
             } else {
                 AdapterResult.Error(ErrorType.DATA_VALIDATION_ERROR)

--- a/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/kpis/vcs/VcsAdapter.kt
+++ b/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/kpis/vcs/VcsAdapter.kt
@@ -27,17 +27,20 @@ object VcsAdapter {
         val repoDetailsDto = data.first()
         return listOf(
             AdapterResult.Success.Kpi(
-                RawValueKpi(kind = KpiId.NUMBER_OF_COMMITS, score = repoDetailsDto.numberOfCommits)
+                RawValueKpi(
+                    kpiId = KpiId.NUMBER_OF_COMMITS.name,
+                    score = repoDetailsDto.numberOfCommits,
+                )
             ),
             AdapterResult.Success.Kpi(
                 RawValueKpi(
-                    kind = KpiId.NUMBER_OF_SIGNED_COMMITS,
+                    kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS.name,
                     score = repoDetailsDto.numberOfSignedCommits,
                 )
             ),
             AdapterResult.Success.Kpi(
                 RawValueKpi(
-                    kind = KpiId.IS_DEFAULT_BRANCH_PROTECTED,
+                    kpiId = KpiId.IS_DEFAULT_BRANCH_PROTECTED.name,
                     score = if (repoDetailsDto.isDefaultBranchProtected) 100 else 0,
                 )
             ),

--- a/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/tools/occmd/OccmdAdapter.kt
+++ b/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/tools/occmd/OccmdAdapter.kt
@@ -24,30 +24,33 @@ object OccmdAdapter {
                 Checks.CheckedInBinaries ->
                     AdapterResult.Success.Kpi(
                         RawValueKpi(
-                            kind = KpiId.CHECKED_IN_BINARIES,
+                            kpiId = KpiId.CHECKED_IN_BINARIES.name,
                             score = (it.score * 100).toInt(),
                         )
                     )
 
                 Checks.SastUsageBasic ->
                     AdapterResult.Success.Kpi(
-                        RawValueKpi(kind = KpiId.SAST_USAGE, score = (it.score * 100).toInt())
+                        RawValueKpi(kpiId = KpiId.SAST_USAGE.name, score = (it.score * 100).toInt())
                     )
 
                 Checks.Secrets ->
                     AdapterResult.Success.Kpi(
-                        RawValueKpi(kind = KpiId.SECRETS, score = (it.score * 100).toInt())
+                        RawValueKpi(kpiId = KpiId.SECRETS.name, score = (it.score * 100).toInt())
                     )
 
                 Checks.CommentsInCode ->
                     AdapterResult.Success.Kpi(
-                        RawValueKpi(kind = KpiId.COMMENTS_IN_CODE, score = (it.score * 100).toInt())
+                        RawValueKpi(
+                            kpiId = KpiId.COMMENTS_IN_CODE.name,
+                            score = (it.score * 100).toInt(),
+                        )
                     )
 
                 Checks.DocumentationInfrastructure ->
                     AdapterResult.Success.Kpi(
                         RawValueKpi(
-                            kind = KpiId.DOCUMENTATION_INFRASTRUCTURE,
+                            kpiId = KpiId.DOCUMENTATION_INFRASTRUCTURE.name,
                             score = (it.score * 100).toInt(),
                         )
                     )

--- a/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/tools/tlc/TlcAdapter.kt
+++ b/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/tools/tlc/TlcAdapter.kt
@@ -64,9 +64,9 @@ object TlcAdapter {
 
                         val rawValueKpi =
                             if (isProductionScope(ecosystem = project.ecosystem, scope = scope)) {
-                                RawValueKpi(score = libyearScore, kind = KpiId.LIB_DAYS_PROD)
+                                RawValueKpi(score = libyearScore, kpiId = KpiId.LIB_DAYS_PROD.name)
                             } else {
-                                RawValueKpi(score = libyearScore, kind = KpiId.LIB_DAYS_DEV)
+                                RawValueKpi(score = libyearScore, kpiId = KpiId.LIB_DAYS_DEV.name)
                             }
 
                         return@map AdapterResult.Success.KpiTechLag(

--- a/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/tools/trufflehog/TrufflehogAdapter.kt
+++ b/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/tools/trufflehog/TrufflehogAdapter.kt
@@ -48,7 +48,7 @@ object TrufflehogAdapter {
     fun transformDataToKpi(data: Collection<TrufflehogReportDto>): Collection<AdapterResult> {
         return data.map {
             val score = if (it.verifiedSecrets > 0) 0 else 100
-            AdapterResult.Success.Kpi(RawValueKpi(score = score, kind = KpiId.SECRETS))
+            AdapterResult.Success.Kpi(RawValueKpi(score = score, kpiId = KpiId.SECRETS.name))
         }
     }
 }

--- a/adapter/src/test/kotlin/de/fraunhofer/iem/spha/adapter/tools/tlc/TlcAdapterTest.kt
+++ b/adapter/src/test/kotlin/de/fraunhofer/iem/spha/adapter/tools/tlc/TlcAdapterTest.kt
@@ -153,7 +153,7 @@ class TlcAdapterTest {
 
         val rawValueKpi = (kpi as AdapterResult.Success).rawValueKpi
 
-        assertEquals(KpiId.LIB_DAYS_PROD, rawValueKpi.kind)
+        assertEquals(KpiId.LIB_DAYS_PROD.name, rawValueKpi.kpiId)
         assertEquals(100, rawValueKpi.score)
 
         val techLag = (kpi as AdapterResult.Success.KpiTechLag)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@
  */
 
 plugins {
-    id("com.github.jmongard.git-semver-plugin") version "0.12.11"
+    id("com.github.jmongard.git-semver-plugin") version "0.13.0"
     id("com.github.ben-manes.versions") version "0.51.0"
 }
 

--- a/core/src/main/kotlin/de/fraunhofer/iem/spha/core/hierarchy/KpiHierarchyNode.kt
+++ b/core/src/main/kotlin/de/fraunhofer/iem/spha/core/hierarchy/KpiHierarchyNode.kt
@@ -9,7 +9,6 @@
 
 package de.fraunhofer.iem.spha.core.hierarchy
 
-import de.fraunhofer.iem.spha.model.kpi.KpiId
 import de.fraunhofer.iem.spha.model.kpi.KpiStrategyId
 import de.fraunhofer.iem.spha.model.kpi.RawValueKpi
 import de.fraunhofer.iem.spha.model.kpi.hierarchy.KpiCalculationResult
@@ -19,7 +18,7 @@ import de.fraunhofer.iem.spha.model.kpi.hierarchy.KpiResultNode
 
 internal class KpiHierarchyNode
 private constructor(
-    val kpiId: KpiId,
+    val kpiId: String,
     val kpiStrategyId: KpiStrategyId,
     val hierarchyEdges: List<KpiHierarchyEdge>,
 ) {
@@ -62,10 +61,14 @@ private constructor(
         }
 
         fun from(node: KpiNode, rawValueKpis: List<RawValueKpi>): KpiHierarchyNode {
-            val kpiIdToValues = mutableMapOf<KpiId, MutableList<RawValueKpi>>()
-            KpiId.entries.forEach { kpiIdToValues[it] = mutableListOf() }
+            val kpiIdToValues = mutableMapOf<String, MutableList<RawValueKpi>>()
 
-            rawValueKpis.forEach { kpiIdToValues[it.kind]!!.add(it) }
+            rawValueKpis.forEach {
+                if (!kpiIdToValues.containsKey(it.kpiId)) {
+                    kpiIdToValues[it.kpiId] = mutableListOf()
+                }
+                kpiIdToValues[it.kpiId]!!.add(it)
+            }
 
             val hierarchy = from(node, kpiIdToValues = kpiIdToValues)
 
@@ -74,7 +77,7 @@ private constructor(
 
         private fun from(
             node: KpiNode,
-            kpiIdToValues: Map<KpiId, List<RawValueKpi>>,
+            kpiIdToValues: Map<String, List<RawValueKpi>>,
         ): KpiHierarchyNode {
 
             val children: MutableList<KpiHierarchyEdge> = mutableListOf()

--- a/core/src/test/kotlin/de/fraunhofer/iem/spha/core/KpiCalculatorTest.kt
+++ b/core/src/test/kotlin/de/fraunhofer/iem/spha/core/KpiCalculatorTest.kt
@@ -29,16 +29,16 @@ class KpiCalculatorTest {
         assertDoesNotThrow {
             val rawValueKpis =
                 listOf(
-                    RawValueKpi(kind = KpiId.CODE_VULNERABILITY_SCORE, score = 8),
-                    RawValueKpi(kind = KpiId.CODE_VULNERABILITY_SCORE, score = 9),
-                    RawValueKpi(kind = KpiId.CHECKED_IN_BINARIES, score = 100),
-                    RawValueKpi(kind = KpiId.COMMENTS_IN_CODE, score = 80),
-                    RawValueKpi(kind = KpiId.NUMBER_OF_COMMITS, score = 90),
-                    RawValueKpi(kind = KpiId.IS_DEFAULT_BRANCH_PROTECTED, score = 100),
-                    RawValueKpi(kind = KpiId.NUMBER_OF_SIGNED_COMMITS, score = 80),
-                    RawValueKpi(kind = KpiId.SECRETS, score = 80),
-                    RawValueKpi(kind = KpiId.SAST_USAGE, score = 80),
-                    RawValueKpi(kind = KpiId.DOCUMENTATION_INFRASTRUCTURE, score = 80),
+                    RawValueKpi(kpiId = KpiId.CODE_VULNERABILITY_SCORE.name, score = 8),
+                    RawValueKpi(kpiId = KpiId.CODE_VULNERABILITY_SCORE.name, score = 9),
+                    RawValueKpi(kpiId = KpiId.CHECKED_IN_BINARIES.name, score = 100),
+                    RawValueKpi(kpiId = KpiId.COMMENTS_IN_CODE.name, score = 80),
+                    RawValueKpi(kpiId = KpiId.NUMBER_OF_COMMITS.name, score = 90),
+                    RawValueKpi(kpiId = KpiId.IS_DEFAULT_BRANCH_PROTECTED.name, score = 100),
+                    RawValueKpi(kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS.name, score = 80),
+                    RawValueKpi(kpiId = KpiId.SECRETS.name, score = 80),
+                    RawValueKpi(kpiId = KpiId.SAST_USAGE.name, score = 80),
+                    RawValueKpi(kpiId = KpiId.DOCUMENTATION_INFRASTRUCTURE.name, score = 80),
                 )
             KpiCalculator.calculateKpis(DefaultHierarchy.get(), rawValueKpis)
         }
@@ -48,28 +48,28 @@ class KpiCalculatorTest {
     fun calculateMaxKpis() {
         val rawValueKpis =
             listOf(
-                RawValueKpi(kind = KpiId.CODE_VULNERABILITY_SCORE, score = 82),
-                RawValueKpi(kind = KpiId.CODE_VULNERABILITY_SCORE, score = 90),
-                RawValueKpi(kind = KpiId.CODE_VULNERABILITY_SCORE, score = 65),
+                RawValueKpi(kpiId = KpiId.CODE_VULNERABILITY_SCORE.name, score = 82),
+                RawValueKpi(kpiId = KpiId.CODE_VULNERABILITY_SCORE.name, score = 90),
+                RawValueKpi(kpiId = KpiId.CODE_VULNERABILITY_SCORE.name, score = 65),
             )
 
         val root =
             KpiNode(
-                kpiId = KpiId.ROOT,
+                kpiId = KpiId.ROOT.name,
                 kpiStrategyId = KpiStrategyId.WEIGHTED_AVERAGE_STRATEGY,
                 edges =
                     listOf(
                         KpiEdge(
                             target =
                                 KpiNode(
-                                    kpiId = KpiId.MAXIMAL_VULNERABILITY,
+                                    kpiId = KpiId.MAXIMAL_VULNERABILITY.name,
                                     kpiStrategyId = KpiStrategyId.MAXIMUM_STRATEGY,
                                     edges =
                                         listOf(
                                             KpiEdge(
                                                 target =
                                                     KpiNode(
-                                                        kpiId = KpiId.CODE_VULNERABILITY_SCORE,
+                                                        kpiId = KpiId.CODE_VULNERABILITY_SCORE.name,
                                                         kpiStrategyId =
                                                             KpiStrategyId.RAW_VALUE_STRATEGY,
                                                         edges = emptyList(),
@@ -98,28 +98,28 @@ class KpiCalculatorTest {
     fun calculateMaxKpisIncomplete() {
         val rawValueKpis =
             listOf(
-                RawValueKpi(kind = KpiId.CODE_VULNERABILITY_SCORE, score = 82),
-                RawValueKpi(kind = KpiId.CODE_VULNERABILITY_SCORE, score = 90),
-                RawValueKpi(kind = KpiId.CODE_VULNERABILITY_SCORE, score = 65),
+                RawValueKpi(kpiId = KpiId.CODE_VULNERABILITY_SCORE.name, score = 82),
+                RawValueKpi(kpiId = KpiId.CODE_VULNERABILITY_SCORE.name, score = 90),
+                RawValueKpi(kpiId = KpiId.CODE_VULNERABILITY_SCORE.name, score = 65),
             )
 
         val root =
             KpiNode(
-                kpiId = KpiId.ROOT,
+                kpiId = KpiId.ROOT.name,
                 kpiStrategyId = KpiStrategyId.WEIGHTED_AVERAGE_STRATEGY,
                 edges =
                     listOf(
                         KpiEdge(
                             target =
                                 KpiNode(
-                                    kpiId = KpiId.SECURITY,
+                                    kpiId = KpiId.SECURITY.name,
                                     kpiStrategyId = KpiStrategyId.MAXIMUM_STRATEGY,
                                     edges =
                                         listOf(
                                             KpiEdge(
                                                 target =
                                                     KpiNode(
-                                                        kpiId = KpiId.CODE_VULNERABILITY_SCORE,
+                                                        kpiId = KpiId.CODE_VULNERABILITY_SCORE.name,
                                                         kpiStrategyId =
                                                             KpiStrategyId.RAW_VALUE_STRATEGY,
                                                         edges = emptyList(),
@@ -129,7 +129,7 @@ class KpiCalculatorTest {
                                             KpiEdge(
                                                 target =
                                                     KpiNode(
-                                                        kpiId = KpiId.SAST_USAGE,
+                                                        kpiId = KpiId.SAST_USAGE.name,
                                                         kpiStrategyId =
                                                             KpiStrategyId.RAW_VALUE_STRATEGY,
                                                         edges = emptyList(),
@@ -158,28 +158,28 @@ class KpiCalculatorTest {
     fun calculateRatioKpisIncomplete() {
         val rawValueKpis =
             listOf(
-                RawValueKpi(kind = KpiId.CODE_VULNERABILITY_SCORE, score = 82),
-                RawValueKpi(kind = KpiId.CODE_VULNERABILITY_SCORE, score = 90),
-                RawValueKpi(kind = KpiId.CODE_VULNERABILITY_SCORE, score = 65),
+                RawValueKpi(kpiId = KpiId.CODE_VULNERABILITY_SCORE.name, score = 82),
+                RawValueKpi(kpiId = KpiId.CODE_VULNERABILITY_SCORE.name, score = 90),
+                RawValueKpi(kpiId = KpiId.CODE_VULNERABILITY_SCORE.name, score = 65),
             )
 
         val root =
             KpiNode(
-                kpiId = KpiId.ROOT,
+                kpiId = KpiId.ROOT.name,
                 kpiStrategyId = KpiStrategyId.WEIGHTED_AVERAGE_STRATEGY,
                 edges =
                     listOf(
                         KpiEdge(
                             target =
                                 KpiNode(
-                                    kpiId = KpiId.SIGNED_COMMITS_RATIO,
+                                    kpiId = KpiId.SIGNED_COMMITS_RATIO.name,
                                     kpiStrategyId = KpiStrategyId.WEIGHTED_RATIO_STRATEGY,
                                     edges =
                                         listOf(
                                             KpiEdge(
                                                 target =
                                                     KpiNode(
-                                                        kpiId = KpiId.NUMBER_OF_COMMITS,
+                                                        kpiId = KpiId.NUMBER_OF_COMMITS.name,
                                                         edges = emptyList(),
                                                         kpiStrategyId =
                                                             KpiStrategyId.RAW_VALUE_STRATEGY,
@@ -189,7 +189,7 @@ class KpiCalculatorTest {
                                             KpiEdge(
                                                 target =
                                                     KpiNode(
-                                                        kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS,
+                                                        kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS.name,
                                                         edges = emptyList(),
                                                         kpiStrategyId =
                                                             KpiStrategyId.RAW_VALUE_STRATEGY,
@@ -203,14 +203,14 @@ class KpiCalculatorTest {
                         KpiEdge(
                             target =
                                 KpiNode(
-                                    kpiId = KpiId.SECURITY,
+                                    kpiId = KpiId.SECURITY.name,
                                     kpiStrategyId = KpiStrategyId.MAXIMUM_STRATEGY,
                                     edges =
                                         listOf(
                                             KpiEdge(
                                                 target =
                                                     KpiNode(
-                                                        kpiId = KpiId.CODE_VULNERABILITY_SCORE,
+                                                        kpiId = KpiId.CODE_VULNERABILITY_SCORE.name,
                                                         kpiStrategyId =
                                                             KpiStrategyId.RAW_VALUE_STRATEGY,
                                                         edges = emptyList(),
@@ -240,20 +240,20 @@ class KpiCalculatorTest {
     fun calculateAggregation() {
         val rawValueKpis =
             listOf(
-                RawValueKpi(kind = KpiId.CODE_VULNERABILITY_SCORE, score = 80),
-                RawValueKpi(kind = KpiId.CODE_VULNERABILITY_SCORE, score = 90),
+                RawValueKpi(kpiId = KpiId.CODE_VULNERABILITY_SCORE.name, score = 80),
+                RawValueKpi(kpiId = KpiId.CODE_VULNERABILITY_SCORE.name, score = 90),
             )
 
         val root =
             KpiNode(
-                kpiId = KpiId.ROOT,
+                kpiId = KpiId.ROOT.name,
                 kpiStrategyId = KpiStrategyId.WEIGHTED_AVERAGE_STRATEGY,
                 edges =
                     listOf(
                         KpiEdge(
                             target =
                                 KpiNode(
-                                    kpiId = KpiId.CODE_VULNERABILITY_SCORE,
+                                    kpiId = KpiId.CODE_VULNERABILITY_SCORE.name,
                                     kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                     edges = listOf(),
                                 ),
@@ -274,23 +274,23 @@ class KpiCalculatorTest {
     }
 
     @Test
-    fun calculateAggregationKpisIncompleteMixedKinds() {
+    fun calculateAggregationKpisIncompleteMixedKpiIds() {
         val rawValueKpis =
             listOf(
-                RawValueKpi(kind = KpiId.CODE_VULNERABILITY_SCORE, score = 80),
-                RawValueKpi(kind = KpiId.CODE_VULNERABILITY_SCORE, score = 90),
+                RawValueKpi(kpiId = KpiId.CODE_VULNERABILITY_SCORE.name, score = 80),
+                RawValueKpi(kpiId = KpiId.CODE_VULNERABILITY_SCORE.name, score = 90),
             )
 
         val root =
             KpiNode(
-                kpiId = KpiId.ROOT,
+                kpiId = KpiId.ROOT.name,
                 kpiStrategyId = KpiStrategyId.WEIGHTED_AVERAGE_STRATEGY,
                 edges =
                     listOf(
                         KpiEdge(
                             target =
                                 KpiNode(
-                                    kpiId = KpiId.CODE_VULNERABILITY_SCORE,
+                                    kpiId = KpiId.CODE_VULNERABILITY_SCORE.name,
                                     kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                     edges = listOf(),
                                 ),
@@ -299,7 +299,7 @@ class KpiCalculatorTest {
                         KpiEdge(
                             target =
                                 KpiNode(
-                                    kpiId = KpiId.SAST_USAGE,
+                                    kpiId = KpiId.SAST_USAGE.name,
                                     kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                     edges = listOf(),
                                 ),
@@ -315,10 +315,12 @@ class KpiCalculatorTest {
         if (result is KpiCalculationResult.Incomplete) {
             assertEquals(85, result.score)
             val sastResult =
-                res.rootNode.children.find { it.target.kpiId == KpiId.SAST_USAGE } ?: fail()
+                res.rootNode.children.find { it.target.kpiId == KpiId.SAST_USAGE.name } ?: fail()
             assertEquals(0.0, sastResult.actualWeight)
             val vulnerabilityEdges =
-                res.rootNode.children.filter { it.target.kpiId == KpiId.CODE_VULNERABILITY_SCORE }
+                res.rootNode.children.filter {
+                    it.target.kpiId == KpiId.CODE_VULNERABILITY_SCORE.name
+                }
             assertEquals(2, vulnerabilityEdges.size)
             assertEquals(vulnerabilityEdges.first().actualWeight, 0.5)
             assertEquals(vulnerabilityEdges[1].actualWeight, 0.5)
@@ -328,30 +330,30 @@ class KpiCalculatorTest {
     }
 
     @Test
-    fun calculateAggregationKpisIncompleteMixedKindsNested() {
+    fun calculateAggregationKpisIncompleteMixedkpiIdsNested() {
         val rawValueKpis =
             listOf(
-                RawValueKpi(kind = KpiId.CODE_VULNERABILITY_SCORE, score = 80),
-                RawValueKpi(kind = KpiId.CODE_VULNERABILITY_SCORE, score = 90),
+                RawValueKpi(kpiId = KpiId.CODE_VULNERABILITY_SCORE.name, score = 80),
+                RawValueKpi(kpiId = KpiId.CODE_VULNERABILITY_SCORE.name, score = 90),
             )
 
         val root =
             KpiNode(
-                kpiId = KpiId.ROOT,
+                kpiId = KpiId.ROOT.name,
                 kpiStrategyId = KpiStrategyId.WEIGHTED_AVERAGE_STRATEGY,
                 edges =
                     listOf(
                         KpiEdge(
                             target =
                                 KpiNode(
-                                    kpiId = KpiId.MAXIMAL_VULNERABILITY,
+                                    kpiId = KpiId.MAXIMAL_VULNERABILITY.name,
                                     kpiStrategyId = KpiStrategyId.MAXIMUM_STRATEGY,
                                     edges =
                                         listOf(
                                             KpiEdge(
                                                 target =
                                                     KpiNode(
-                                                        kpiId = KpiId.CODE_VULNERABILITY_SCORE,
+                                                        kpiId = KpiId.CODE_VULNERABILITY_SCORE.name,
                                                         kpiStrategyId =
                                                             KpiStrategyId.RAW_VALUE_STRATEGY,
                                                         edges = listOf(),
@@ -365,7 +367,7 @@ class KpiCalculatorTest {
                         KpiEdge(
                             target =
                                 KpiNode(
-                                    kpiId = KpiId.SAST_USAGE,
+                                    kpiId = KpiId.SAST_USAGE.name,
                                     kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                     edges = listOf(),
                                 ),
@@ -381,10 +383,10 @@ class KpiCalculatorTest {
         if (result is KpiCalculationResult.Incomplete) {
             assertEquals(90, result.score)
             val sastResult =
-                res.rootNode.children.find { it.target.kpiId == KpiId.SAST_USAGE } ?: fail()
+                res.rootNode.children.find { it.target.kpiId == KpiId.SAST_USAGE.name } ?: fail()
             assertEquals(0.0, sastResult.actualWeight)
             val vulnerabilityEdges =
-                res.rootNode.children.filter { it.target.kpiId == KpiId.MAXIMAL_VULNERABILITY }
+                res.rootNode.children.filter { it.target.kpiId == KpiId.MAXIMAL_VULNERABILITY.name }
             assertEquals(vulnerabilityEdges.first().actualWeight, 1.0)
             assertEquals(vulnerabilityEdges.first().plannedWeight, 0.5)
         } else {

--- a/core/src/test/kotlin/de/fraunhofer/iem/spha/core/NodeTestHelper.kt
+++ b/core/src/test/kotlin/de/fraunhofer/iem/spha/core/NodeTestHelper.kt
@@ -22,7 +22,7 @@ internal fun randomKpiHierarchyNode(): KpiHierarchyNode {
 
     return KpiHierarchyNode.from(
         KpiNode(
-            kpiId = KpiId.entries[rndIds],
+            kpiId = KpiId.entries[rndIds].name,
             kpiStrategyId = KpiStrategyId.entries[rndStrategies],
             edges = listOf(),
         ),
@@ -36,7 +36,7 @@ fun randomNode(edges: List<KpiEdge> = listOf()): KpiNode {
     val rndStrategies = (0..<KpiStrategyId.entries.size).random()
 
     return KpiNode(
-        kpiId = KpiId.entries[rndIds],
+        kpiId = KpiId.entries[rndIds].name,
         kpiStrategyId = KpiStrategyId.entries[rndStrategies],
         edges = edges,
     )

--- a/core/src/test/kotlin/de/fraunhofer/iem/spha/core/hierarchy/HierarchyValidatorTest.kt
+++ b/core/src/test/kotlin/de/fraunhofer/iem/spha/core/hierarchy/HierarchyValidatorTest.kt
@@ -26,7 +26,7 @@ class HierarchyValidatorTest {
             KpiHierarchy.create(
                 rootNode =
                     KpiNode(
-                        kpiId = KpiId.ROOT,
+                        kpiId = KpiId.ROOT.name,
                         kpiStrategyId = KpiStrategyId.WEIGHTED_AVERAGE_STRATEGY,
                         edges = emptyList(),
                     )
@@ -42,14 +42,14 @@ class HierarchyValidatorTest {
             KpiHierarchy.create(
                 rootNode =
                     KpiNode(
-                        kpiId = KpiId.ROOT,
+                        kpiId = KpiId.ROOT.name,
                         kpiStrategyId = KpiStrategyId.WEIGHTED_AVERAGE_STRATEGY,
                         edges =
                             listOf(
                                 KpiEdge(
                                     KpiNode(
                                         kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
-                                        kpiId = KpiId.NUMBER_OF_COMMITS,
+                                        kpiId = KpiId.NUMBER_OF_COMMITS.name,
                                         edges = listOf(KpiEdge(target = randomNode(), weight = 1.0)),
                                     ),
                                     weight = 1.0,
@@ -71,14 +71,14 @@ class HierarchyValidatorTest {
             KpiHierarchy.create(
                 rootNode =
                     KpiNode(
-                        kpiId = KpiId.ROOT,
+                        kpiId = KpiId.ROOT.name,
                         kpiStrategyId = KpiStrategyId.WEIGHTED_AVERAGE_STRATEGY,
                         edges =
                             listOf(
                                 KpiEdge(
                                     KpiNode(
                                         kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
-                                        kpiId = KpiId.NUMBER_OF_COMMITS,
+                                        kpiId = KpiId.NUMBER_OF_COMMITS.name,
                                         edges = listOf(),
                                     ),
                                     weight = 1.0,

--- a/core/src/test/kotlin/de/fraunhofer/iem/spha/core/strategy/AbstractKpiCalculationTest.kt
+++ b/core/src/test/kotlin/de/fraunhofer/iem/spha/core/strategy/AbstractKpiCalculationTest.kt
@@ -26,13 +26,13 @@ import org.junit.jupiter.api.Test
 internal fun getNodeWithErrorResult(plannedWeight: Double): KpiHierarchyNode {
     val node =
         KpiNode(
-            kpiId = KpiId.NUMBER_OF_COMMITS,
+            kpiId = KpiId.NUMBER_OF_COMMITS.name,
             kpiStrategyId = KpiStrategyId.WEIGHTED_RATIO_STRATEGY,
             edges =
                 listOf(
                     KpiEdge(
                         KpiNode(
-                            kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS,
+                            kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS.name,
                             kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                             edges = listOf(),
                         ),
@@ -42,7 +42,10 @@ internal fun getNodeWithErrorResult(plannedWeight: Double): KpiHierarchyNode {
         )
 
     val hierarchyNode =
-        KpiHierarchyNode.from(node, listOf(RawValueKpi(KpiId.NUMBER_OF_SIGNED_COMMITS, score = 20)))
+        KpiHierarchyNode.from(
+            node,
+            listOf(RawValueKpi(KpiId.NUMBER_OF_SIGNED_COMMITS.name, score = 20)),
+        )
     KpiCalculator.calculateKpi(hierarchyNode)
     return hierarchyNode
 }
@@ -51,13 +54,13 @@ internal fun getNodeIncompleteResult(plannedWeight: Double): KpiHierarchyNode {
 
     val node =
         KpiNode(
-            kpiId = KpiId.SECRETS,
+            kpiId = KpiId.SECRETS.name,
             kpiStrategyId = KpiStrategyId.WEIGHTED_AVERAGE_STRATEGY,
             edges =
                 listOf(
                     KpiEdge(
                         KpiNode(
-                            kpiId = KpiId.NUMBER_OF_COMMITS,
+                            kpiId = KpiId.NUMBER_OF_COMMITS.name,
                             kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                             edges = listOf(),
                         ),
@@ -65,7 +68,7 @@ internal fun getNodeIncompleteResult(plannedWeight: Double): KpiHierarchyNode {
                     ),
                     KpiEdge(
                         KpiNode(
-                            kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS,
+                            kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS.name,
                             kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                             edges = listOf(),
                         ),
@@ -75,7 +78,10 @@ internal fun getNodeIncompleteResult(plannedWeight: Double): KpiHierarchyNode {
         )
 
     val hierarchyNode =
-        KpiHierarchyNode.from(node, listOf(RawValueKpi(KpiId.NUMBER_OF_SIGNED_COMMITS, score = 20)))
+        KpiHierarchyNode.from(
+            node,
+            listOf(RawValueKpi(KpiId.NUMBER_OF_SIGNED_COMMITS.name, score = 20)),
+        )
     return hierarchyNode
 }
 
@@ -103,14 +109,14 @@ class AbstractKpiCalculationTest {
 
         val nodeCorrectChildren =
             KpiNode(
-                kpiId = KpiId.ROOT,
+                kpiId = KpiId.ROOT.name,
                 kpiStrategyId = KpiStrategyId.WEIGHTED_RATIO_STRATEGY,
                 edges =
                     listOf(
                         KpiEdge(
                             target =
                                 KpiNode(
-                                    kpiId = KpiId.NUMBER_OF_COMMITS,
+                                    kpiId = KpiId.NUMBER_OF_COMMITS.name,
                                     kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                     edges = listOf(),
                                 ),
@@ -119,7 +125,7 @@ class AbstractKpiCalculationTest {
                         KpiEdge(
                             target =
                                 KpiNode(
-                                    kpiId = KpiId.NUMBER_OF_COMMITS,
+                                    kpiId = KpiId.NUMBER_OF_COMMITS.name,
                                     kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                     edges = listOf(),
                                 ),
@@ -131,7 +137,7 @@ class AbstractKpiCalculationTest {
         val root =
             KpiHierarchyNode.from(
                 nodeCorrectChildren,
-                listOf(RawValueKpi(KpiId.NUMBER_OF_COMMITS, 20)),
+                listOf(RawValueKpi(KpiId.NUMBER_OF_COMMITS.name, 20)),
             )
 
         fun callback(edges: Collection<KpiHierarchyEdge>) {

--- a/core/src/test/kotlin/de/fraunhofer/iem/spha/core/strategy/AggregationKpiCalculationStrategyTest.kt
+++ b/core/src/test/kotlin/de/fraunhofer/iem/spha/core/strategy/AggregationKpiCalculationStrategyTest.kt
@@ -44,14 +44,14 @@ class AggregationKpiCalculationStrategyTest {
         val root =
             KpiHierarchyNode.from(
                 KpiNode(
-                    kpiId = KpiId.ROOT,
+                    kpiId = KpiId.ROOT.name,
                     kpiStrategyId = KpiStrategyId.MAXIMUM_STRATEGY,
                     edges =
                         listOf(
                             KpiEdge(
                                 target =
                                     KpiNode(
-                                        kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS,
+                                        kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS.name,
                                         kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                         edges = listOf(),
                                     ),
@@ -60,7 +60,7 @@ class AggregationKpiCalculationStrategyTest {
                             KpiEdge(
                                 target =
                                     KpiNode(
-                                        kpiId = KpiId.NUMBER_OF_COMMITS,
+                                        kpiId = KpiId.NUMBER_OF_COMMITS.name,
                                         kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                         edges = listOf(),
                                     ),
@@ -69,8 +69,8 @@ class AggregationKpiCalculationStrategyTest {
                         ),
                 ),
                 listOf(
-                    RawValueKpi(kind = KpiId.NUMBER_OF_SIGNED_COMMITS, score = 15),
-                    RawValueKpi(kind = KpiId.NUMBER_OF_COMMITS, score = 20),
+                    RawValueKpi(kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS.name, score = 15),
+                    RawValueKpi(kpiId = KpiId.NUMBER_OF_COMMITS.name, score = 20),
                 ),
             )
 

--- a/core/src/test/kotlin/de/fraunhofer/iem/spha/core/strategy/AndKPICalculationStrategyTest.kt
+++ b/core/src/test/kotlin/de/fraunhofer/iem/spha/core/strategy/AndKPICalculationStrategyTest.kt
@@ -8,7 +8,7 @@ import de.fraunhofer.iem.spha.model.kpi.hierarchy.KpiCalculationResult
 import de.fraunhofer.iem.spha.model.kpi.hierarchy.KpiEdge
 import de.fraunhofer.iem.spha.model.kpi.hierarchy.KpiNode
 import kotlin.test.Test
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
 
 class AndKPICalculationStrategyTest {
 
@@ -29,14 +29,14 @@ class AndKPICalculationStrategyTest {
         val root =
             KpiHierarchyNode.from(
                 KpiNode(
-                    kpiId = KpiId.ROOT,
+                    kpiId = KpiId.ROOT.name,
                     kpiStrategyId = KpiStrategyId.XOR_STRATEGY,
                     edges =
                         listOf(
                             KpiEdge(
                                 target =
                                     KpiNode(
-                                        kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS,
+                                        kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS.name,
                                         kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                         edges = listOf(),
                                     ),
@@ -45,7 +45,7 @@ class AndKPICalculationStrategyTest {
                             KpiEdge(
                                 target =
                                     KpiNode(
-                                        kpiId = KpiId.NUMBER_OF_COMMITS,
+                                        kpiId = KpiId.NUMBER_OF_COMMITS.name,
                                         kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                         edges = listOf(),
                                     ),
@@ -54,8 +54,8 @@ class AndKPICalculationStrategyTest {
                         ),
                 ),
                 listOf(
-                    RawValueKpi(kind = KpiId.NUMBER_OF_SIGNED_COMMITS, score = 100),
-                    RawValueKpi(kind = KpiId.NUMBER_OF_COMMITS, score = 20),
+                    RawValueKpi(kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS.name, score = 100),
+                    RawValueKpi(kpiId = KpiId.NUMBER_OF_COMMITS.name, score = 20),
                 ),
             )
 
@@ -83,14 +83,14 @@ class AndKPICalculationStrategyTest {
         val root =
             KpiHierarchyNode.from(
                 KpiNode(
-                    kpiId = KpiId.ROOT,
+                    kpiId = KpiId.ROOT.name,
                     kpiStrategyId = KpiStrategyId.XOR_STRATEGY,
                     edges =
                         listOf(
                             KpiEdge(
                                 target =
                                     KpiNode(
-                                        kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS,
+                                        kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS.name,
                                         kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                         edges = listOf(),
                                     ),
@@ -99,7 +99,7 @@ class AndKPICalculationStrategyTest {
                             KpiEdge(
                                 target =
                                     KpiNode(
-                                        kpiId = KpiId.NUMBER_OF_COMMITS,
+                                        kpiId = KpiId.NUMBER_OF_COMMITS.name,
                                         kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                         edges = listOf(),
                                     ),
@@ -108,8 +108,8 @@ class AndKPICalculationStrategyTest {
                         ),
                 ),
                 listOf(
-                    RawValueKpi(kind = KpiId.NUMBER_OF_SIGNED_COMMITS, score = 100),
-                    RawValueKpi(kind = KpiId.NUMBER_OF_COMMITS, score = 100),
+                    RawValueKpi(kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS.name, score = 100),
+                    RawValueKpi(kpiId = KpiId.NUMBER_OF_COMMITS.name, score = 100),
                 ),
             )
 

--- a/core/src/test/kotlin/de/fraunhofer/iem/spha/core/strategy/MaximumKPICalculationStrategyTest.kt
+++ b/core/src/test/kotlin/de/fraunhofer/iem/spha/core/strategy/MaximumKPICalculationStrategyTest.kt
@@ -38,14 +38,14 @@ class MaximumKPICalculationStrategyTest {
         val root =
             KpiHierarchyNode.from(
                 KpiNode(
-                    kpiId = KpiId.ROOT,
+                    kpiId = KpiId.ROOT.name,
                     kpiStrategyId = KpiStrategyId.MAXIMUM_STRATEGY,
                     edges =
                         listOf(
                             KpiEdge(
                                 target =
                                     KpiNode(
-                                        kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS,
+                                        kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS.name,
                                         kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                         edges = listOf(),
                                     ),
@@ -54,7 +54,7 @@ class MaximumKPICalculationStrategyTest {
                             KpiEdge(
                                 target =
                                     KpiNode(
-                                        kpiId = KpiId.NUMBER_OF_COMMITS,
+                                        kpiId = KpiId.NUMBER_OF_COMMITS.name,
                                         kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                         edges = listOf(),
                                     ),
@@ -63,8 +63,8 @@ class MaximumKPICalculationStrategyTest {
                         ),
                 ),
                 listOf(
-                    RawValueKpi(kind = KpiId.NUMBER_OF_SIGNED_COMMITS, score = 15),
-                    RawValueKpi(kind = KpiId.NUMBER_OF_COMMITS, score = 20),
+                    RawValueKpi(kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS.name, score = 15),
+                    RawValueKpi(kpiId = KpiId.NUMBER_OF_COMMITS.name, score = 20),
                 ),
             )
 

--- a/core/src/test/kotlin/de/fraunhofer/iem/spha/core/strategy/MinimumKPICalculationStrategyTest.kt
+++ b/core/src/test/kotlin/de/fraunhofer/iem/spha/core/strategy/MinimumKPICalculationStrategyTest.kt
@@ -38,14 +38,14 @@ class MinimumKPICalculationStrategyTest {
         val root =
             KpiHierarchyNode.from(
                 KpiNode(
-                    kpiId = KpiId.ROOT,
+                    kpiId = KpiId.ROOT.name,
                     kpiStrategyId = KpiStrategyId.MINIMUM_STRATEGY,
                     edges =
                         listOf(
                             KpiEdge(
                                 target =
                                     KpiNode(
-                                        kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS,
+                                        kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS.name,
                                         kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                         edges = listOf(),
                                     ),
@@ -54,7 +54,7 @@ class MinimumKPICalculationStrategyTest {
                             KpiEdge(
                                 target =
                                     KpiNode(
-                                        kpiId = KpiId.NUMBER_OF_COMMITS,
+                                        kpiId = KpiId.NUMBER_OF_COMMITS.name,
                                         kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                         edges = listOf(),
                                     ),
@@ -63,8 +63,8 @@ class MinimumKPICalculationStrategyTest {
                         ),
                 ),
                 listOf(
-                    RawValueKpi(kind = KpiId.NUMBER_OF_SIGNED_COMMITS, score = 15),
-                    RawValueKpi(kind = KpiId.NUMBER_OF_COMMITS, score = 20),
+                    RawValueKpi(kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS.name, score = 15),
+                    RawValueKpi(kpiId = KpiId.NUMBER_OF_COMMITS.name, score = 20),
                 ),
             )
 

--- a/core/src/test/kotlin/de/fraunhofer/iem/spha/core/strategy/OrKPICalculationStrategyTest.kt
+++ b/core/src/test/kotlin/de/fraunhofer/iem/spha/core/strategy/OrKPICalculationStrategyTest.kt
@@ -8,7 +8,7 @@ import de.fraunhofer.iem.spha.model.kpi.hierarchy.KpiCalculationResult
 import de.fraunhofer.iem.spha.model.kpi.hierarchy.KpiEdge
 import de.fraunhofer.iem.spha.model.kpi.hierarchy.KpiNode
 import kotlin.test.Test
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
 
 class OrKPICalculationStrategyTest {
 
@@ -29,14 +29,14 @@ class OrKPICalculationStrategyTest {
         val root =
             KpiHierarchyNode.from(
                 KpiNode(
-                    kpiId = KpiId.ROOT,
+                    kpiId = KpiId.ROOT.name,
                     kpiStrategyId = KpiStrategyId.XOR_STRATEGY,
                     edges =
                         listOf(
                             KpiEdge(
                                 target =
                                     KpiNode(
-                                        kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS,
+                                        kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS.name,
                                         kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                         edges = listOf(),
                                     ),
@@ -45,7 +45,7 @@ class OrKPICalculationStrategyTest {
                             KpiEdge(
                                 target =
                                     KpiNode(
-                                        kpiId = KpiId.NUMBER_OF_COMMITS,
+                                        kpiId = KpiId.NUMBER_OF_COMMITS.name,
                                         kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                         edges = listOf(),
                                     ),
@@ -54,8 +54,8 @@ class OrKPICalculationStrategyTest {
                         ),
                 ),
                 listOf(
-                    RawValueKpi(kind = KpiId.NUMBER_OF_SIGNED_COMMITS, score = 50),
-                    RawValueKpi(kind = KpiId.NUMBER_OF_COMMITS, score = 20),
+                    RawValueKpi(kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS.name, score = 50),
+                    RawValueKpi(kpiId = KpiId.NUMBER_OF_COMMITS.name, score = 20),
                 ),
             )
 
@@ -83,14 +83,14 @@ class OrKPICalculationStrategyTest {
         val root =
             KpiHierarchyNode.from(
                 KpiNode(
-                    kpiId = KpiId.ROOT,
+                    kpiId = KpiId.ROOT.name,
                     kpiStrategyId = KpiStrategyId.XOR_STRATEGY,
                     edges =
                         listOf(
                             KpiEdge(
                                 target =
                                     KpiNode(
-                                        kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS,
+                                        kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS.name,
                                         kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                         edges = listOf(),
                                     ),
@@ -99,7 +99,7 @@ class OrKPICalculationStrategyTest {
                             KpiEdge(
                                 target =
                                     KpiNode(
-                                        kpiId = KpiId.NUMBER_OF_COMMITS,
+                                        kpiId = KpiId.NUMBER_OF_COMMITS.name,
                                         kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                         edges = listOf(),
                                     ),
@@ -108,8 +108,8 @@ class OrKPICalculationStrategyTest {
                         ),
                 ),
                 listOf(
-                    RawValueKpi(kind = KpiId.NUMBER_OF_SIGNED_COMMITS, score = 100),
-                    RawValueKpi(kind = KpiId.NUMBER_OF_COMMITS, score = 20),
+                    RawValueKpi(kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS.name, score = 100),
+                    RawValueKpi(kpiId = KpiId.NUMBER_OF_COMMITS.name, score = 20),
                 ),
             )
 

--- a/core/src/test/kotlin/de/fraunhofer/iem/spha/core/strategy/WeightedMaximumKPICalculationStrategyTest.kt
+++ b/core/src/test/kotlin/de/fraunhofer/iem/spha/core/strategy/WeightedMaximumKPICalculationStrategyTest.kt
@@ -44,14 +44,14 @@ class WeightedMaximumKPICalculationStrategyTest {
         val root =
             KpiHierarchyNode.from(
                 KpiNode(
-                    kpiId = KpiId.ROOT,
+                    kpiId = KpiId.ROOT.name,
                     kpiStrategyId = KpiStrategyId.MAXIMUM_STRATEGY,
                     edges =
                         listOf(
                             KpiEdge(
                                 target =
                                     KpiNode(
-                                        kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS,
+                                        kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS.name,
                                         kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                         edges = listOf(),
                                     ),
@@ -60,7 +60,7 @@ class WeightedMaximumKPICalculationStrategyTest {
                             KpiEdge(
                                 target =
                                     KpiNode(
-                                        kpiId = KpiId.NUMBER_OF_COMMITS,
+                                        kpiId = KpiId.NUMBER_OF_COMMITS.name,
                                         kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                         edges = listOf(),
                                     ),
@@ -69,8 +69,8 @@ class WeightedMaximumKPICalculationStrategyTest {
                         ),
                 ),
                 listOf(
-                    RawValueKpi(kind = KpiId.NUMBER_OF_SIGNED_COMMITS, score = 15),
-                    RawValueKpi(kind = KpiId.NUMBER_OF_COMMITS, score = 20),
+                    RawValueKpi(kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS.name, score = 15),
+                    RawValueKpi(kpiId = KpiId.NUMBER_OF_COMMITS.name, score = 20),
                 ),
             )
 

--- a/core/src/test/kotlin/de/fraunhofer/iem/spha/core/strategy/WeightedMinimumKPICalculationStrategyTest.kt
+++ b/core/src/test/kotlin/de/fraunhofer/iem/spha/core/strategy/WeightedMinimumKPICalculationStrategyTest.kt
@@ -44,14 +44,14 @@ class WeightedMinimumKPICalculationStrategyTest {
         val root =
             KpiHierarchyNode.from(
                 KpiNode(
-                    kpiId = KpiId.ROOT,
+                    kpiId = KpiId.ROOT.name,
                     kpiStrategyId = KpiStrategyId.MAXIMUM_STRATEGY,
                     edges =
                         listOf(
                             KpiEdge(
                                 target =
                                     KpiNode(
-                                        kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS,
+                                        kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS.name,
                                         kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                         edges = listOf(),
                                     ),
@@ -60,7 +60,7 @@ class WeightedMinimumKPICalculationStrategyTest {
                             KpiEdge(
                                 target =
                                     KpiNode(
-                                        kpiId = KpiId.NUMBER_OF_COMMITS,
+                                        kpiId = KpiId.NUMBER_OF_COMMITS.name,
                                         kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                         edges = listOf(),
                                     ),
@@ -69,8 +69,8 @@ class WeightedMinimumKPICalculationStrategyTest {
                         ),
                 ),
                 listOf(
-                    RawValueKpi(kind = KpiId.NUMBER_OF_SIGNED_COMMITS, score = 15),
-                    RawValueKpi(kind = KpiId.NUMBER_OF_COMMITS, score = 20),
+                    RawValueKpi(kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS.name, score = 15),
+                    RawValueKpi(kpiId = KpiId.NUMBER_OF_COMMITS.name, score = 20),
                 ),
             )
 

--- a/core/src/test/kotlin/de/fraunhofer/iem/spha/core/strategy/WeightedRatioKPICalculationStrategyTest.kt
+++ b/core/src/test/kotlin/de/fraunhofer/iem/spha/core/strategy/WeightedRatioKPICalculationStrategyTest.kt
@@ -17,7 +17,7 @@ import de.fraunhofer.iem.spha.model.kpi.RawValueKpi
 import de.fraunhofer.iem.spha.model.kpi.hierarchy.KpiCalculationResult
 import de.fraunhofer.iem.spha.model.kpi.hierarchy.KpiEdge
 import de.fraunhofer.iem.spha.model.kpi.hierarchy.KpiNode
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class WeightedRatioKPICalculationStrategyTest {
@@ -26,7 +26,7 @@ class WeightedRatioKPICalculationStrategyTest {
     fun isValidEmpty() {
         val node =
             KpiNode(
-                kpiId = KpiId.ROOT,
+                kpiId = KpiId.ROOT.name,
                 kpiStrategyId = KpiStrategyId.WEIGHTED_RATIO_STRATEGY,
                 edges = listOf(),
             )
@@ -36,7 +36,7 @@ class WeightedRatioKPICalculationStrategyTest {
 
         val incorrectStrategy =
             KpiNode(
-                kpiId = KpiId.ROOT,
+                kpiId = KpiId.ROOT.name,
                 kpiStrategyId = KpiStrategyId.WEIGHTED_AVERAGE_STRATEGY,
                 edges = listOf(),
             )
@@ -73,14 +73,14 @@ class WeightedRatioKPICalculationStrategyTest {
     fun isValidCorrectChildren() {
         val nodeCorrectChildren =
             KpiNode(
-                kpiId = KpiId.ROOT,
+                kpiId = KpiId.ROOT.name,
                 kpiStrategyId = KpiStrategyId.WEIGHTED_RATIO_STRATEGY,
                 edges =
                     listOf(
                         KpiEdge(
                             target =
                                 KpiNode(
-                                    kpiId = KpiId.NUMBER_OF_COMMITS,
+                                    kpiId = KpiId.NUMBER_OF_COMMITS.name,
                                     kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                     edges = listOf(),
                                 ),
@@ -89,7 +89,7 @@ class WeightedRatioKPICalculationStrategyTest {
                         KpiEdge(
                             target =
                                 KpiNode(
-                                    kpiId = KpiId.NUMBER_OF_COMMITS,
+                                    kpiId = KpiId.NUMBER_OF_COMMITS.name,
                                     kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                     edges = listOf(),
                                 ),
@@ -113,14 +113,14 @@ class WeightedRatioKPICalculationStrategyTest {
         val root =
             KpiHierarchyNode.from(
                 KpiNode(
-                    kpiId = KpiId.ROOT,
+                    kpiId = KpiId.ROOT.name,
                     kpiStrategyId = KpiStrategyId.MAXIMUM_STRATEGY,
                     edges =
                         listOf(
                             KpiEdge(
                                 target =
                                     KpiNode(
-                                        kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS,
+                                        kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS.name,
                                         kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                         edges = listOf(),
                                     ),
@@ -129,7 +129,7 @@ class WeightedRatioKPICalculationStrategyTest {
                             KpiEdge(
                                 target =
                                     KpiNode(
-                                        kpiId = KpiId.NUMBER_OF_COMMITS,
+                                        kpiId = KpiId.NUMBER_OF_COMMITS.name,
                                         kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                         edges = listOf(),
                                     ),
@@ -138,8 +138,8 @@ class WeightedRatioKPICalculationStrategyTest {
                         ),
                 ),
                 listOf(
-                    RawValueKpi(kind = KpiId.NUMBER_OF_SIGNED_COMMITS, score = 15),
-                    RawValueKpi(kind = KpiId.NUMBER_OF_COMMITS, score = 20),
+                    RawValueKpi(kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS.name, score = 15),
+                    RawValueKpi(kpiId = KpiId.NUMBER_OF_COMMITS.name, score = 20),
                 ),
             )
 
@@ -165,14 +165,14 @@ class WeightedRatioKPICalculationStrategyTest {
     fun isValidToManyChildren() {
         val nodeManyChildren =
             KpiNode(
-                kpiId = KpiId.ROOT,
+                kpiId = KpiId.ROOT.name,
                 kpiStrategyId = KpiStrategyId.WEIGHTED_RATIO_STRATEGY,
                 edges =
                     listOf(
                         KpiEdge(
                             target =
                                 KpiNode(
-                                    kpiId = KpiId.NUMBER_OF_COMMITS,
+                                    kpiId = KpiId.NUMBER_OF_COMMITS.name,
                                     kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                     edges = listOf(),
                                 ),
@@ -181,7 +181,7 @@ class WeightedRatioKPICalculationStrategyTest {
                         KpiEdge(
                             target =
                                 KpiNode(
-                                    kpiId = KpiId.NUMBER_OF_COMMITS,
+                                    kpiId = KpiId.NUMBER_OF_COMMITS.name,
                                     kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                     edges = listOf(),
                                 ),
@@ -190,7 +190,7 @@ class WeightedRatioKPICalculationStrategyTest {
                         KpiEdge(
                             target =
                                 KpiNode(
-                                    kpiId = KpiId.NUMBER_OF_COMMITS,
+                                    kpiId = KpiId.NUMBER_OF_COMMITS.name,
                                     kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                     edges = listOf(),
                                 ),
@@ -211,7 +211,7 @@ class WeightedRatioKPICalculationStrategyTest {
         val root =
             KpiHierarchyNode.from(
                 nodeManyChildren,
-                listOf(RawValueKpi(kind = KpiId.NUMBER_OF_COMMITS, score = 15)),
+                listOf(RawValueKpi(kpiId = KpiId.NUMBER_OF_COMMITS.name, score = 15)),
             )
 
         val relaxed =
@@ -226,14 +226,14 @@ class WeightedRatioKPICalculationStrategyTest {
     fun nestedError() {
         val nestedError =
             KpiNode(
-                kpiId = KpiId.ROOT,
+                kpiId = KpiId.ROOT.name,
                 kpiStrategyId = KpiStrategyId.WEIGHTED_RATIO_STRATEGY,
                 edges =
                     listOf(
                         KpiEdge(
                             target =
                                 KpiNode(
-                                    kpiId = KpiId.NUMBER_OF_COMMITS,
+                                    kpiId = KpiId.NUMBER_OF_COMMITS.name,
                                     kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                     edges = listOf(),
                                 ),
@@ -242,14 +242,14 @@ class WeightedRatioKPICalculationStrategyTest {
                         KpiEdge(
                             target =
                                 KpiNode(
-                                    kpiId = KpiId.SECURITY,
+                                    kpiId = KpiId.SECURITY.name,
                                     kpiStrategyId = KpiStrategyId.WEIGHTED_RATIO_STRATEGY,
                                     edges =
                                         listOf(
                                             KpiEdge(
                                                 target =
                                                     KpiNode(
-                                                        kpiId = KpiId.NUMBER_OF_COMMITS,
+                                                        kpiId = KpiId.NUMBER_OF_COMMITS.name,
                                                         kpiStrategyId =
                                                             KpiStrategyId.RAW_VALUE_STRATEGY,
                                                         edges = listOf(),
@@ -259,7 +259,7 @@ class WeightedRatioKPICalculationStrategyTest {
                                             KpiEdge(
                                                 target =
                                                     KpiNode(
-                                                        kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS,
+                                                        kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS.name,
                                                         kpiStrategyId =
                                                             KpiStrategyId.RAW_VALUE_STRATEGY,
                                                         edges = listOf(),
@@ -277,8 +277,8 @@ class WeightedRatioKPICalculationStrategyTest {
             KpiHierarchyNode.from(
                 nestedError,
                 listOf(
-                    RawValueKpi(kind = KpiId.NUMBER_OF_COMMITS, score = 0),
-                    RawValueKpi(kind = KpiId.NUMBER_OF_SIGNED_COMMITS, score = -1),
+                    RawValueKpi(kpiId = KpiId.NUMBER_OF_COMMITS.name, score = 0),
+                    RawValueKpi(kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS.name, score = -1),
                 ),
             )
 
@@ -307,14 +307,14 @@ class WeightedRatioKPICalculationStrategyTest {
     fun isValidToFewChildren() {
         val nodeToFewChildren =
             KpiNode(
-                kpiId = KpiId.ROOT,
+                kpiId = KpiId.ROOT.name,
                 kpiStrategyId = KpiStrategyId.WEIGHTED_RATIO_STRATEGY,
                 edges =
                     listOf(
                         KpiEdge(
                             target =
                                 KpiNode(
-                                    kpiId = KpiId.NUMBER_OF_COMMITS,
+                                    kpiId = KpiId.NUMBER_OF_COMMITS.name,
                                     kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                     edges = listOf(),
                                 ),

--- a/core/src/test/kotlin/de/fraunhofer/iem/spha/core/strategy/XorKPICalculationStrategyTest.kt
+++ b/core/src/test/kotlin/de/fraunhofer/iem/spha/core/strategy/XorKPICalculationStrategyTest.kt
@@ -8,7 +8,7 @@ import de.fraunhofer.iem.spha.model.kpi.hierarchy.KpiCalculationResult
 import de.fraunhofer.iem.spha.model.kpi.hierarchy.KpiEdge
 import de.fraunhofer.iem.spha.model.kpi.hierarchy.KpiNode
 import kotlin.test.Test
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
 
 class XorKPICalculationStrategyTest {
 
@@ -28,14 +28,14 @@ class XorKPICalculationStrategyTest {
     fun tooManyEdges() {
         val nodeManyChildren =
             KpiNode(
-                kpiId = KpiId.ROOT,
+                kpiId = KpiId.ROOT.name,
                 kpiStrategyId = KpiStrategyId.XOR_STRATEGY,
                 edges =
                     listOf(
                         KpiEdge(
                             target =
                                 KpiNode(
-                                    kpiId = KpiId.NUMBER_OF_COMMITS,
+                                    kpiId = KpiId.NUMBER_OF_COMMITS.name,
                                     kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                     edges = listOf(),
                                 ),
@@ -44,7 +44,7 @@ class XorKPICalculationStrategyTest {
                         KpiEdge(
                             target =
                                 KpiNode(
-                                    kpiId = KpiId.NUMBER_OF_COMMITS,
+                                    kpiId = KpiId.NUMBER_OF_COMMITS.name,
                                     kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                     edges = listOf(),
                                 ),
@@ -53,7 +53,7 @@ class XorKPICalculationStrategyTest {
                         KpiEdge(
                             target =
                                 KpiNode(
-                                    kpiId = KpiId.NUMBER_OF_COMMITS,
+                                    kpiId = KpiId.NUMBER_OF_COMMITS.name,
                                     kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                     edges = listOf(),
                                 ),
@@ -74,7 +74,7 @@ class XorKPICalculationStrategyTest {
         val root =
             KpiHierarchyNode.from(
                 nodeManyChildren,
-                listOf(RawValueKpi(kind = KpiId.NUMBER_OF_COMMITS, score = 15)),
+                listOf(RawValueKpi(kpiId = KpiId.NUMBER_OF_COMMITS.name, score = 15)),
             )
 
         val relaxed = XorKPICalculationStrategy.calculateKpi(root.hierarchyEdges, strict = false)
@@ -88,14 +88,14 @@ class XorKPICalculationStrategyTest {
         val root =
             KpiHierarchyNode.from(
                 KpiNode(
-                    kpiId = KpiId.ROOT,
+                    kpiId = KpiId.ROOT.name,
                     kpiStrategyId = KpiStrategyId.XOR_STRATEGY,
                     edges =
                         listOf(
                             KpiEdge(
                                 target =
                                     KpiNode(
-                                        kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS,
+                                        kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS.name,
                                         kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                         edges = listOf(),
                                     ),
@@ -104,7 +104,7 @@ class XorKPICalculationStrategyTest {
                             KpiEdge(
                                 target =
                                     KpiNode(
-                                        kpiId = KpiId.NUMBER_OF_COMMITS,
+                                        kpiId = KpiId.NUMBER_OF_COMMITS.name,
                                         kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                         edges = listOf(),
                                     ),
@@ -113,8 +113,8 @@ class XorKPICalculationStrategyTest {
                         ),
                 ),
                 listOf(
-                    RawValueKpi(kind = KpiId.NUMBER_OF_SIGNED_COMMITS, score = 50),
-                    RawValueKpi(kind = KpiId.NUMBER_OF_COMMITS, score = 20),
+                    RawValueKpi(kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS.name, score = 50),
+                    RawValueKpi(kpiId = KpiId.NUMBER_OF_COMMITS.name, score = 20),
                 ),
             )
 
@@ -142,14 +142,14 @@ class XorKPICalculationStrategyTest {
         val root =
             KpiHierarchyNode.from(
                 KpiNode(
-                    kpiId = KpiId.ROOT,
+                    kpiId = KpiId.ROOT.name,
                     kpiStrategyId = KpiStrategyId.XOR_STRATEGY,
                     edges =
                         listOf(
                             KpiEdge(
                                 target =
                                     KpiNode(
-                                        kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS,
+                                        kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS.name,
                                         kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                         edges = listOf(),
                                     ),
@@ -158,7 +158,7 @@ class XorKPICalculationStrategyTest {
                             KpiEdge(
                                 target =
                                     KpiNode(
-                                        kpiId = KpiId.NUMBER_OF_COMMITS,
+                                        kpiId = KpiId.NUMBER_OF_COMMITS.name,
                                         kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                         edges = listOf(),
                                     ),
@@ -167,8 +167,8 @@ class XorKPICalculationStrategyTest {
                         ),
                 ),
                 listOf(
-                    RawValueKpi(kind = KpiId.NUMBER_OF_SIGNED_COMMITS, score = 100),
-                    RawValueKpi(kind = KpiId.NUMBER_OF_COMMITS, score = 100),
+                    RawValueKpi(kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS.name, score = 100),
+                    RawValueKpi(kpiId = KpiId.NUMBER_OF_COMMITS.name, score = 100),
                 ),
             )
 
@@ -193,14 +193,14 @@ class XorKPICalculationStrategyTest {
         val rootZero =
             KpiHierarchyNode.from(
                 KpiNode(
-                    kpiId = KpiId.ROOT,
+                    kpiId = KpiId.ROOT.name,
                     kpiStrategyId = KpiStrategyId.XOR_STRATEGY,
                     edges =
                         listOf(
                             KpiEdge(
                                 target =
                                     KpiNode(
-                                        kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS,
+                                        kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS.name,
                                         kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                         edges = listOf(),
                                     ),
@@ -209,7 +209,7 @@ class XorKPICalculationStrategyTest {
                             KpiEdge(
                                 target =
                                     KpiNode(
-                                        kpiId = KpiId.NUMBER_OF_COMMITS,
+                                        kpiId = KpiId.NUMBER_OF_COMMITS.name,
                                         kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                         edges = listOf(),
                                     ),
@@ -218,8 +218,8 @@ class XorKPICalculationStrategyTest {
                         ),
                 ),
                 listOf(
-                    RawValueKpi(kind = KpiId.NUMBER_OF_SIGNED_COMMITS, score = 0),
-                    RawValueKpi(kind = KpiId.NUMBER_OF_COMMITS, score = 0),
+                    RawValueKpi(kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS.name, score = 0),
+                    RawValueKpi(kpiId = KpiId.NUMBER_OF_COMMITS.name, score = 0),
                 ),
             )
 
@@ -247,14 +247,14 @@ class XorKPICalculationStrategyTest {
         val root =
             KpiHierarchyNode.from(
                 KpiNode(
-                    kpiId = KpiId.ROOT,
+                    kpiId = KpiId.ROOT.name,
                     kpiStrategyId = KpiStrategyId.XOR_STRATEGY,
                     edges =
                         listOf(
                             KpiEdge(
                                 target =
                                     KpiNode(
-                                        kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS,
+                                        kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS.name,
                                         kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                         edges = listOf(),
                                     ),
@@ -263,7 +263,7 @@ class XorKPICalculationStrategyTest {
                             KpiEdge(
                                 target =
                                     KpiNode(
-                                        kpiId = KpiId.NUMBER_OF_COMMITS,
+                                        kpiId = KpiId.NUMBER_OF_COMMITS.name,
                                         kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                                         edges = listOf(),
                                     ),
@@ -272,8 +272,8 @@ class XorKPICalculationStrategyTest {
                         ),
                 ),
                 listOf(
-                    RawValueKpi(kind = KpiId.NUMBER_OF_SIGNED_COMMITS, score = 100),
-                    RawValueKpi(kind = KpiId.NUMBER_OF_COMMITS, score = 20),
+                    RawValueKpi(kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS.name, score = 100),
+                    RawValueKpi(kpiId = KpiId.NUMBER_OF_COMMITS.name, score = 20),
                 ),
             )
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
-kotlin = "2.0.21"
+kotlin = "2.1.0"
 kotlinxSerialization = "1.7.3"
-kotlinPlugin = "2.0.21"
-kotlinLogging = "7.0.0"
+kotlinPlugin = "2.1.0"
+kotlinLogging = "7.0.3"
 slf4jApi = "2.0.16"
 junit = "5.11.3"
 mockk = "1.13.13"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/model/src/main/kotlin/de/fraunhofer/iem/spha/model/kpi/RawValueKpi.kt
+++ b/model/src/main/kotlin/de/fraunhofer/iem/spha/model/kpi/RawValueKpi.kt
@@ -11,4 +11,4 @@ package de.fraunhofer.iem.spha.model.kpi
 
 import kotlinx.serialization.Serializable
 
-@Serializable data class RawValueKpi(val kind: KpiId, val score: Int)
+@Serializable data class RawValueKpi(val kpiId: String, val score: Int)

--- a/model/src/main/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/DefaultHierarchy.kt
+++ b/model/src/main/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/DefaultHierarchy.kt
@@ -17,56 +17,56 @@ object DefaultHierarchy {
 
         val secrets =
             KpiNode(
-                kpiId = KpiId.SECRETS,
+                kpiId = KpiId.SECRETS.name,
                 kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                 edges = listOf(),
             )
 
         val documentationInfrastructure =
             KpiNode(
-                kpiId = KpiId.DOCUMENTATION_INFRASTRUCTURE,
+                kpiId = KpiId.DOCUMENTATION_INFRASTRUCTURE.name,
                 kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                 edges = listOf(),
             )
 
         val commentsInCode =
             KpiNode(
-                kpiId = KpiId.COMMENTS_IN_CODE,
+                kpiId = KpiId.COMMENTS_IN_CODE.name,
                 kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                 edges = listOf(),
             )
 
         val numberOfCommits =
             KpiNode(
-                kpiId = KpiId.NUMBER_OF_COMMITS,
+                kpiId = KpiId.NUMBER_OF_COMMITS.name,
                 kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                 edges = listOf(),
             )
 
         val numberOfSignedCommits =
             KpiNode(
-                kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS,
+                kpiId = KpiId.NUMBER_OF_SIGNED_COMMITS.name,
                 kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                 edges = listOf(),
             )
 
         val isDefaultBranchProtected =
             KpiNode(
-                kpiId = KpiId.IS_DEFAULT_BRANCH_PROTECTED,
+                kpiId = KpiId.IS_DEFAULT_BRANCH_PROTECTED.name,
                 kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                 edges = listOf(),
             )
 
         val checkedInBinaries =
             KpiNode(
-                kpiId = KpiId.CHECKED_IN_BINARIES,
+                kpiId = KpiId.CHECKED_IN_BINARIES.name,
                 kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                 edges = listOf(),
             )
 
         val signedCommitsRatio =
             KpiNode(
-                kpiId = KpiId.SIGNED_COMMITS_RATIO,
+                kpiId = KpiId.SIGNED_COMMITS_RATIO.name,
                 kpiStrategyId = KpiStrategyId.WEIGHTED_RATIO_STRATEGY,
                 edges =
                     listOf(
@@ -77,7 +77,7 @@ object DefaultHierarchy {
 
         val documentation =
             KpiNode(
-                kpiId = KpiId.DOCUMENTATION,
+                kpiId = KpiId.DOCUMENTATION.name,
                 kpiStrategyId = KpiStrategyId.WEIGHTED_AVERAGE_STRATEGY,
                 edges =
                     listOf(
@@ -88,7 +88,7 @@ object DefaultHierarchy {
 
         val processComplianceKpi =
             KpiNode(
-                kpiId = KpiId.PROCESS_COMPLIANCE,
+                kpiId = KpiId.PROCESS_COMPLIANCE.name,
                 kpiStrategyId = KpiStrategyId.WEIGHTED_AVERAGE_STRATEGY,
                 edges =
                     listOf(
@@ -101,42 +101,42 @@ object DefaultHierarchy {
 
         val processTransparency =
             KpiNode(
-                kpiId = KpiId.PROCESS_TRANSPARENCY,
+                kpiId = KpiId.PROCESS_TRANSPARENCY.name,
                 kpiStrategyId = KpiStrategyId.WEIGHTED_AVERAGE_STRATEGY,
                 edges = listOf(KpiEdge(target = signedCommitsRatio, weight = 1.0)),
             )
 
         val codeVulnerabilities =
             KpiNode(
-                kpiId = KpiId.CODE_VULNERABILITY_SCORE,
+                kpiId = KpiId.CODE_VULNERABILITY_SCORE.name,
                 kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                 edges = listOf(),
             )
 
         val maxDepVulnerability =
             KpiNode(
-                kpiId = KpiId.MAXIMAL_VULNERABILITY,
+                kpiId = KpiId.MAXIMAL_VULNERABILITY.name,
                 kpiStrategyId = KpiStrategyId.MINIMUM_STRATEGY,
                 edges = listOf(KpiEdge(target = codeVulnerabilities, weight = 1.0)),
             )
 
         val containerVulnerabilities =
             KpiNode(
-                kpiId = KpiId.CONTAINER_VULNERABILITY_SCORE,
+                kpiId = KpiId.CONTAINER_VULNERABILITY_SCORE.name,
                 kpiStrategyId = KpiStrategyId.RAW_VALUE_STRATEGY,
                 edges = listOf(),
             )
 
         val maxContainerVulnerability =
             KpiNode(
-                kpiId = KpiId.MAXIMAL_VULNERABILITY,
+                kpiId = KpiId.MAXIMAL_VULNERABILITY.name,
                 kpiStrategyId = KpiStrategyId.MAXIMUM_STRATEGY,
                 edges = listOf(KpiEdge(target = containerVulnerabilities, weight = 1.0)),
             )
 
         val security =
             KpiNode(
-                kpiId = KpiId.SECURITY,
+                kpiId = KpiId.SECURITY.name,
                 kpiStrategyId = KpiStrategyId.WEIGHTED_AVERAGE_STRATEGY,
                 edges =
                     listOf(
@@ -149,21 +149,21 @@ object DefaultHierarchy {
 
         val internalQuality =
             KpiNode(
-                kpiId = KpiId.INTERNAL_QUALITY,
+                kpiId = KpiId.INTERNAL_QUALITY.name,
                 kpiStrategyId = KpiStrategyId.WEIGHTED_AVERAGE_STRATEGY,
                 edges = listOf(KpiEdge(target = documentation, weight = 1.0)),
             )
 
         val externalQuality =
             KpiNode(
-                kpiId = KpiId.EXTERNAL_QUALITY,
+                kpiId = KpiId.EXTERNAL_QUALITY.name,
                 kpiStrategyId = KpiStrategyId.WEIGHTED_AVERAGE_STRATEGY,
                 edges = listOf(KpiEdge(target = documentation, weight = 1.0)),
             )
 
         val root =
             KpiNode(
-                kpiId = KpiId.ROOT,
+                kpiId = KpiId.ROOT.name,
                 kpiStrategyId = KpiStrategyId.WEIGHTED_AVERAGE_STRATEGY,
                 edges =
                     listOf(

--- a/model/src/main/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/KpiHierarchy.kt
+++ b/model/src/main/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/KpiHierarchy.kt
@@ -9,7 +9,6 @@
 
 package de.fraunhofer.iem.spha.model.kpi.hierarchy
 
-import de.fraunhofer.iem.spha.model.kpi.KpiId
 import de.fraunhofer.iem.spha.model.kpi.KpiStrategyId
 import kotlinx.serialization.Serializable
 
@@ -25,6 +24,6 @@ data class KpiHierarchy private constructor(val rootNode: KpiNode, val schemaVer
 }
 
 @Serializable
-data class KpiNode(val kpiId: KpiId, val kpiStrategyId: KpiStrategyId, val edges: List<KpiEdge>)
+data class KpiNode(val kpiId: String, val kpiStrategyId: KpiStrategyId, val edges: List<KpiEdge>)
 
 @Serializable data class KpiEdge(val target: KpiNode, val weight: Double)

--- a/model/src/main/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/KpiResultHierarchy.kt
+++ b/model/src/main/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/KpiResultHierarchy.kt
@@ -9,7 +9,6 @@
 
 package de.fraunhofer.iem.spha.model.kpi.hierarchy
 
-import de.fraunhofer.iem.spha.model.kpi.KpiId
 import de.fraunhofer.iem.spha.model.kpi.KpiStrategyId
 import kotlinx.serialization.Serializable
 
@@ -24,7 +23,7 @@ private constructor(val rootNode: KpiResultNode, val schemaVersion: String) {
 
 @Serializable
 data class KpiResultNode(
-    val kpiId: KpiId,
+    val kpiId: String,
     val kpiResult: KpiCalculationResult,
     val strategyType: KpiStrategyId,
     val children: List<KpiResultEdge>,

--- a/model/src/test/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/KpiHierarchyTest.kt
+++ b/model/src/test/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/KpiHierarchyTest.kt
@@ -33,7 +33,7 @@ class KpiHierarchyTest {
                 listOf(
                     KpiEdge(
                         KpiNode(
-                            kpiId = KpiId.SECURITY,
+                            kpiId = KpiId.SECURITY.name,
                             KpiStrategyId.WEIGHTED_AVERAGE_STRATEGY,
                             listOf(),
                         ),
@@ -41,7 +41,7 @@ class KpiHierarchyTest {
                     ),
                     KpiEdge(
                         KpiNode(
-                            kpiId = KpiId.PROCESS_COMPLIANCE,
+                            kpiId = KpiId.PROCESS_COMPLIANCE.name,
                             KpiStrategyId.WEIGHTED_AVERAGE_STRATEGY,
                             listOf(),
                         ),
@@ -49,7 +49,7 @@ class KpiHierarchyTest {
                     ),
                     KpiEdge(
                         KpiNode(
-                            kpiId = KpiId.INTERNAL_QUALITY,
+                            kpiId = KpiId.INTERNAL_QUALITY.name,
                             KpiStrategyId.WEIGHTED_AVERAGE_STRATEGY,
                             listOf(),
                         ),
@@ -58,7 +58,7 @@ class KpiHierarchyTest {
                 )
             val root =
                 KpiNode(
-                    kpiId = KpiId.ROOT,
+                    kpiId = KpiId.ROOT.name,
                     kpiStrategyId = KpiStrategyId.WEIGHTED_AVERAGE_STRATEGY,
                     childNodes,
                 )


### PR DESCRIPTION
To verify the correctness of the changes I ran the local tests in SPHA. 
Further, I integrated the changed version with both, the data-provider, and SPHA-CLI and made the necessary changes to support the type change. See https://github.com/fraunhofer-iem/spha-cli/pull/23 for how this change affects client code.
