### PR TITLE
Add thresholds to KPI Hierarchy and Result hierarchy

### DIFF
--- a/core/src/main/kotlin/de/fraunhofer/iem/spha/core/hierarchy/KpiHierarchyNode.kt
+++ b/core/src/main/kotlin/de/fraunhofer/iem/spha/core/hierarchy/KpiHierarchyNode.kt
@@ -25,6 +25,7 @@ private constructor(
     val tags: Set<String> = emptySet(),
     val originId: String? = null,
     val reason: String? = null,
+    val thresholds: Map<String, Int> = emptyMap(),
 ) {
     private var _id: String = UUID.randomUUID().toString()
     val id: String
@@ -38,7 +39,8 @@ private constructor(
         tags: Set<String> = emptySet(),
         originId: String? = null,
         reason: String? = null,
-    ) : this(typeId, strategy, edges, tags, originId, reason) {
+        thresholds: Map<String, Int> = emptyMap(),
+    ) : this(typeId, strategy, edges, tags, originId, reason, thresholds) {
         this._id = id
     }
 
@@ -72,6 +74,7 @@ private constructor(
                 id = node.id,
                 reason = node.reason,
                 tags = node.tags,
+                thresholds = node.thresholds,
                 edges =
                     node.edges.map {
                         KpiResultEdge(
@@ -118,6 +121,7 @@ private constructor(
                                 originId = rawValueKpi.originId,
                                 id = rawValueKpi.id,
                                 reason = child.target.reason,
+                                thresholds = child.target.thresholds,
                             )
                         hierarchyNode.result = KpiCalculationResult.Success(rawValueKpi.score)
                         val edge =
@@ -144,6 +148,7 @@ private constructor(
                     strategy = node.strategy,
                     reason = node.reason,
                     tags = node.tags,
+                    thresholds = node.thresholds,
                 )
 
             return calcNode

--- a/core/src/main/kotlin/de/fraunhofer/iem/spha/core/hierarchy/KpiHierarchyNode.kt
+++ b/core/src/main/kotlin/de/fraunhofer/iem/spha/core/hierarchy/KpiHierarchyNode.kt
@@ -15,6 +15,7 @@ import de.fraunhofer.iem.spha.model.kpi.hierarchy.KpiCalculationResult
 import de.fraunhofer.iem.spha.model.kpi.hierarchy.KpiNode
 import de.fraunhofer.iem.spha.model.kpi.hierarchy.KpiResultEdge
 import de.fraunhofer.iem.spha.model.kpi.hierarchy.KpiResultNode
+import de.fraunhofer.iem.spha.model.kpi.hierarchy.Threshold
 import java.util.UUID
 
 internal class KpiHierarchyNode
@@ -25,7 +26,7 @@ private constructor(
     val tags: Set<String> = emptySet(),
     val originId: String? = null,
     val reason: String? = null,
-    val thresholds: Map<String, Int> = emptyMap(),
+    val thresholds: List<Threshold> = emptyList(),
 ) {
     private var _id: String = UUID.randomUUID().toString()
     val id: String
@@ -39,7 +40,7 @@ private constructor(
         tags: Set<String> = emptySet(),
         originId: String? = null,
         reason: String? = null,
-        thresholds: Map<String, Int> = emptyMap(),
+        thresholds: List<Threshold> = emptyList(),
     ) : this(typeId, strategy, edges, tags, originId, reason, thresholds) {
         this._id = id
     }

--- a/core/src/test/kotlin/de/fraunhofer/iem/spha/core/KpiCalculatorTest.kt
+++ b/core/src/test/kotlin/de/fraunhofer/iem/spha/core/KpiCalculatorTest.kt
@@ -417,7 +417,7 @@ class KpiCalculatorTest {
                 edges = emptyList(),
                 tags = setOf("cvss", "cve", "cwe"),
                 reason = "CRA relevant",
-                thresholds = mapOf("warning" to 50, "critical" to 90)
+                thresholds = mapOf("warning" to 50, "critical" to 90),
             )
 
         val root =

--- a/core/src/test/kotlin/de/fraunhofer/iem/spha/core/KpiCalculatorTest.kt
+++ b/core/src/test/kotlin/de/fraunhofer/iem/spha/core/KpiCalculatorTest.kt
@@ -18,6 +18,7 @@ import de.fraunhofer.iem.spha.model.kpi.hierarchy.KpiEdge
 import de.fraunhofer.iem.spha.model.kpi.hierarchy.KpiHierarchy
 import de.fraunhofer.iem.spha.model.kpi.hierarchy.KpiNode
 import de.fraunhofer.iem.spha.model.kpi.hierarchy.SCHEMA_VERSIONS
+import de.fraunhofer.iem.spha.model.kpi.hierarchy.Threshold
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
@@ -417,7 +418,7 @@ class KpiCalculatorTest {
                 edges = emptyList(),
                 tags = setOf("cvss", "cve", "cwe"),
                 reason = "CRA relevant",
-                thresholds = mapOf("warning" to 50, "critical" to 90),
+                thresholds = listOf(Threshold("warning", 50), Threshold("critical", 90)),
             )
 
         val root =
@@ -451,7 +452,10 @@ class KpiCalculatorTest {
         assertEquals(setOf(), cvssResultNode.tags)
         assertEquals("cvssOrigin", cvssResultNode.originId)
         assertEquals("CRA relevant", cvssResultNode.reason)
-        assertEquals(mapOf("warning" to 50, "critical" to 90), cvssResultNode.thresholds)
+        assertEquals(
+            listOf(Threshold("warning", 50), Threshold("critical", 90)),
+            cvssResultNode.thresholds,
+        )
 
         // Check SAST Node
         val sastResultNode =

--- a/core/src/test/kotlin/de/fraunhofer/iem/spha/core/KpiCalculatorTest.kt
+++ b/core/src/test/kotlin/de/fraunhofer/iem/spha/core/KpiCalculatorTest.kt
@@ -417,6 +417,7 @@ class KpiCalculatorTest {
                 edges = emptyList(),
                 tags = setOf("cvss", "cve", "cwe"),
                 reason = "CRA relevant",
+                thresholds = mapOf("warning" to 50, "critical" to 90)
             )
 
         val root =
@@ -450,6 +451,7 @@ class KpiCalculatorTest {
         assertEquals(setOf(), cvssResultNode.tags)
         assertEquals("cvssOrigin", cvssResultNode.originId)
         assertEquals("CRA relevant", cvssResultNode.reason)
+        assertEquals(mapOf("warning" to 50, "critical" to 90), cvssResultNode.thresholds)
 
         // Check SAST Node
         val sastResultNode =

--- a/model/src/main/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/KpiHierarchy.kt
+++ b/model/src/main/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/KpiHierarchy.kt
@@ -30,7 +30,7 @@ data class KpiNode(
     val edges: List<KpiEdge>,
     val tags: Set<String> = emptySet(),
     val reason: String? = null,
-    val thresholds: Map<String, Int> = emptyMap(),
+    val thresholds: List<Threshold> = emptyList(),
 )
 
 @Serializable data class KpiEdge(val target: KpiNode, val weight: Double)

--- a/model/src/main/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/KpiHierarchy.kt
+++ b/model/src/main/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/KpiHierarchy.kt
@@ -30,6 +30,7 @@ data class KpiNode(
     val edges: List<KpiEdge>,
     val tags: Set<String> = emptySet(),
     val reason: String? = null,
+    val thresholds: Map<String, Int> = emptyMap(),
 )
 
 @Serializable data class KpiEdge(val target: KpiNode, val weight: Double)

--- a/model/src/main/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/KpiResultHierarchy.kt
+++ b/model/src/main/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/KpiResultHierarchy.kt
@@ -36,7 +36,7 @@ data class KpiResultNode(
     val tags: Set<String> = emptySet(),
     val originId: String? = null,
     val reason: String? = null,
-    val thresholds: Map<String, Int> = emptyMap(),
+    val thresholds: List<Threshold> = emptyList(),
 ) {
     @SerialName("id") private var _id: String = UUID.randomUUID().toString()
     val id: String
@@ -51,7 +51,7 @@ data class KpiResultNode(
         tags: Set<String> = emptySet(),
         originId: String? = null,
         reason: String? = null,
-        thresholds: Map<String, Int> = emptyMap(),
+        thresholds: List<Threshold> = emptyList(),
     ) : this(
         typeId = typeId,
         result = result,

--- a/model/src/main/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/KpiResultHierarchy.kt
+++ b/model/src/main/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/KpiResultHierarchy.kt
@@ -36,7 +36,7 @@ data class KpiResultNode(
     val tags: Set<String> = emptySet(),
     val originId: String? = null,
     val reason: String? = null,
-    val thresholds: Map<String, Int> = emptyMap()
+    val thresholds: Map<String, Int> = emptyMap(),
 ) {
     @SerialName("id") private var _id: String = UUID.randomUUID().toString()
     val id: String
@@ -60,7 +60,7 @@ data class KpiResultNode(
         tags = tags,
         originId = originId,
         reason = reason,
-        thresholds = thresholds
+        thresholds = thresholds,
     ) {
         this._id = id
     }

--- a/model/src/main/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/KpiResultHierarchy.kt
+++ b/model/src/main/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/KpiResultHierarchy.kt
@@ -36,6 +36,7 @@ data class KpiResultNode(
     val tags: Set<String> = emptySet(),
     val originId: String? = null,
     val reason: String? = null,
+    val thresholds: Map<String, Int> = emptyMap()
 ) {
     @SerialName("id") private var _id: String = UUID.randomUUID().toString()
     val id: String
@@ -50,6 +51,7 @@ data class KpiResultNode(
         tags: Set<String> = emptySet(),
         originId: String? = null,
         reason: String? = null,
+        thresholds: Map<String, Int> = emptyMap(),
     ) : this(
         typeId = typeId,
         result = result,
@@ -58,6 +60,7 @@ data class KpiResultNode(
         tags = tags,
         originId = originId,
         reason = reason,
+        thresholds = thresholds
     ) {
         this._id = id
     }

--- a/model/src/main/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/Threshold.kt
+++ b/model/src/main/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/Threshold.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Fraunhofer IEM. All rights reserved.
+ *
+ * Licensed under the MIT license. See LICENSE file in the project root for details.
+ *
+ * SPDX-License-Identifier: MIT
+ * License-Filename: LICENSE
+ */
+
+package de.fraunhofer.iem.spha.model.kpi.hierarchy
+
+import kotlinx.serialization.Serializable
+
+@Serializable data class Threshold(val name: String, val value: Int)

--- a/model/src/test/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/JsonKpiHierarchyTest.kt
+++ b/model/src/test/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/JsonKpiHierarchyTest.kt
@@ -75,7 +75,8 @@ class JsonKpiHierarchyTest {
                                     edges = emptyList(),
                                     tags = setOf("cvss", "cve", "cwe"),
                                     reason = "CRA relevant",
-                                    thresholds = mapOf("warning" to 50, "critical" to 90),
+                                    thresholds =
+                                        listOf(Threshold("warning", 50), Threshold("critical", 90)),
                                 ),
                         )
                     ),
@@ -86,7 +87,7 @@ class JsonKpiHierarchyTest {
         // Pretty printing might add spaces, tabs, (CR)LF, etc. which is hard to assert against.
         // This implicitly asserts that KpiNode and KpiEdge get serialized to the expected JSON too
         val expected =
-            "{\"root\":{\"typeId\":\"ROOT\",\"strategy\":\"MAXIMUM_STRATEGY\",\"edges\":[{\"target\":{\"typeId\":\"CODE_VULNERABILITY_SCORE\",\"strategy\":\"RAW_VALUE_STRATEGY\",\"edges\":[],\"tags\":[\"cvss\",\"cve\",\"cwe\"],\"reason\":\"CRA relevant\",\"thresholds\":{\"warning\":50,\"critical\":90}},\"weight\":1.0}]},\"schemaVersion\":\"1.1.0\"}"
+            "{\"root\":{\"typeId\":\"ROOT\",\"strategy\":\"MAXIMUM_STRATEGY\",\"edges\":[{\"target\":{\"typeId\":\"CODE_VULNERABILITY_SCORE\",\"strategy\":\"RAW_VALUE_STRATEGY\",\"edges\":[],\"tags\":[\"cvss\",\"cve\",\"cwe\"],\"reason\":\"CRA relevant\",\"thresholds\":[{\"name\":\"warning\",\"value\":50},{\"name\":\"critical\",\"value\":90}]},\"weight\":1.0}]},\"schemaVersion\":\"1.1.0\"}"
 
         assertEquals(expected, jsonResult)
     }
@@ -99,7 +100,7 @@ class JsonKpiHierarchyTest {
                     typeId = "someId",
                     strategy = KpiStrategyId.RAW_VALUE_STRATEGY,
                     edges = listOf(),
-                    thresholds = mapOf(),
+                    thresholds = listOf(),
                 ),
                 KpiNode(
                     typeId = "someId",
@@ -107,7 +108,7 @@ class JsonKpiHierarchyTest {
                     edges = listOf(),
                     tags = setOf("A", "B", "a", "b", "A"),
                     reason = "someReason",
-                    thresholds = mapOf("warning" to 50, "critical" to 90),
+                    thresholds = listOf(Threshold("warning", 50), Threshold("critical", 90)),
                 ),
             )
     }

--- a/model/src/test/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/JsonKpiHierarchyTest.kt
+++ b/model/src/test/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/JsonKpiHierarchyTest.kt
@@ -75,6 +75,7 @@ class JsonKpiHierarchyTest {
                                     edges = emptyList(),
                                     tags = setOf("cvss", "cve", "cwe"),
                                     reason = "CRA relevant",
+                                    thresholds = mapOf("warning" to 50, "critical" to 90)
                                 ),
                         )
                     ),
@@ -85,7 +86,7 @@ class JsonKpiHierarchyTest {
         // Pretty printing might add spaces, tabs, (CR)LF, etc. which is hard to assert against.
         // This implicitly asserts that KpiNode and KpiEdge get serialized to the expected JSON too
         val expected =
-            "{\"root\":{\"typeId\":\"ROOT\",\"strategy\":\"MAXIMUM_STRATEGY\",\"edges\":[{\"target\":{\"typeId\":\"CODE_VULNERABILITY_SCORE\",\"strategy\":\"RAW_VALUE_STRATEGY\",\"edges\":[],\"tags\":[\"cvss\",\"cve\",\"cwe\"],\"reason\":\"CRA relevant\"},\"weight\":1.0}]},\"schemaVersion\":\"1.1.0\"}"
+            "{\"root\":{\"typeId\":\"ROOT\",\"strategy\":\"MAXIMUM_STRATEGY\",\"edges\":[{\"target\":{\"typeId\":\"CODE_VULNERABILITY_SCORE\",\"strategy\":\"RAW_VALUE_STRATEGY\",\"edges\":[],\"tags\":[\"cvss\",\"cve\",\"cwe\"],\"reason\":\"CRA relevant\",\"thresholds\":{\"warning\":50,\"critical\":90}},\"weight\":1.0}]},\"schemaVersion\":\"1.1.0\"}"
 
         assertEquals(expected, jsonResult)
     }
@@ -98,6 +99,7 @@ class JsonKpiHierarchyTest {
                     typeId = "someId",
                     strategy = KpiStrategyId.RAW_VALUE_STRATEGY,
                     edges = listOf(),
+                    thresholds = mapOf()
                 ),
                 KpiNode(
                     typeId = "someId",
@@ -105,6 +107,7 @@ class JsonKpiHierarchyTest {
                     edges = listOf(),
                     tags = setOf("A", "B", "a", "b", "A"),
                     reason = "someReason",
+                    thresholds = mapOf("warning" to 50, "critical" to 90)
                 ),
             )
     }

--- a/model/src/test/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/JsonKpiHierarchyTest.kt
+++ b/model/src/test/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/JsonKpiHierarchyTest.kt
@@ -75,7 +75,7 @@ class JsonKpiHierarchyTest {
                                     edges = emptyList(),
                                     tags = setOf("cvss", "cve", "cwe"),
                                     reason = "CRA relevant",
-                                    thresholds = mapOf("warning" to 50, "critical" to 90)
+                                    thresholds = mapOf("warning" to 50, "critical" to 90),
                                 ),
                         )
                     ),
@@ -99,7 +99,7 @@ class JsonKpiHierarchyTest {
                     typeId = "someId",
                     strategy = KpiStrategyId.RAW_VALUE_STRATEGY,
                     edges = listOf(),
-                    thresholds = mapOf()
+                    thresholds = mapOf(),
                 ),
                 KpiNode(
                     typeId = "someId",
@@ -107,7 +107,7 @@ class JsonKpiHierarchyTest {
                     edges = listOf(),
                     tags = setOf("A", "B", "a", "b", "A"),
                     reason = "someReason",
-                    thresholds = mapOf("warning" to 50, "critical" to 90)
+                    thresholds = mapOf("warning" to 50, "critical" to 90),
                 ),
             )
     }

--- a/model/src/test/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/JsonKpiResultHierarchyTest.kt
+++ b/model/src/test/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/JsonKpiResultHierarchyTest.kt
@@ -75,7 +75,7 @@ class JsonKpiResultHierarchyTest {
                                     tags = setOf("A", "B", "a", "b", "A"),
                                     originId = "someOrigin",
                                     reason = "CRA relevant",
-                                    thresholds = mapOf("warning" to 50, "critical" to 90)
+                                    thresholds = mapOf("warning" to 50, "critical" to 90),
                                 ),
                         )
                     ),
@@ -105,7 +105,7 @@ class JsonKpiResultHierarchyTest {
                     result = KpiCalculationResult.Success(42),
                     strategy = KpiStrategyId.RAW_VALUE_STRATEGY,
                     edges = listOf(),
-                    thresholds = mapOf()
+                    thresholds = mapOf(),
                 ),
                 KpiResultNode(
                     typeId = "someId",
@@ -116,7 +116,7 @@ class JsonKpiResultHierarchyTest {
                     tags = setOf("A", "B", "a", "b", "A"),
                     originId = "someOrigin",
                     reason = "someReason",
-                    thresholds = mapOf("warning" to 50, "critical" to 90)
+                    thresholds = mapOf("warning" to 50, "critical" to 90),
                 ),
                 KpiResultNode(
                     typeId = "someId",

--- a/model/src/test/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/JsonKpiResultHierarchyTest.kt
+++ b/model/src/test/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/JsonKpiResultHierarchyTest.kt
@@ -75,7 +75,8 @@ class JsonKpiResultHierarchyTest {
                                     tags = setOf("A", "B", "a", "b", "A"),
                                     originId = "someOrigin",
                                     reason = "CRA relevant",
-                                    thresholds = mapOf("warning" to 50, "critical" to 90),
+                                    thresholds =
+                                        listOf(Threshold("warning", 50), Threshold("critical", 90)),
                                 ),
                         )
                     ),
@@ -91,7 +92,7 @@ class JsonKpiResultHierarchyTest {
         // This implicitly asserts that KpiResultNode and KpiResultEdge get serialized to the
         // expected JSON too
         val expected =
-            "{\"root\":{\"typeId\":\"ROOT\",\"result\":{\"type\":\"de.fraunhofer.iem.spha.model.kpi.hierarchy.KpiCalculationResult.Success\",\"score\":100},\"strategy\":\"MAXIMUM_STRATEGY\",\"edges\":[{\"target\":{\"typeId\":\"CODE_VULNERABILITY_SCORE\",\"result\":{\"type\":\"de.fraunhofer.iem.spha.model.kpi.hierarchy.KpiCalculationResult.Success\",\"score\":100},\"strategy\":\"RAW_VALUE_STRATEGY\",\"edges\":[],\"tags\":[\"A\",\"B\",\"a\",\"b\"],\"originId\":\"someOrigin\",\"reason\":\"CRA relevant\",\"thresholds\":{\"warning\":50,\"critical\":90},\"id\":\"cveId\"},\"plannedWeight\":1.0,\"actualWeight\":0.5}],\"id\":\"rootId\"},\"schemaVersion\":\"1.1.0\",\"timestamp\":\"${hierarchy.timestamp}\"}"
+            "{\"root\":{\"typeId\":\"ROOT\",\"result\":{\"type\":\"de.fraunhofer.iem.spha.model.kpi.hierarchy.KpiCalculationResult.Success\",\"score\":100},\"strategy\":\"MAXIMUM_STRATEGY\",\"edges\":[{\"target\":{\"typeId\":\"CODE_VULNERABILITY_SCORE\",\"result\":{\"type\":\"de.fraunhofer.iem.spha.model.kpi.hierarchy.KpiCalculationResult.Success\",\"score\":100},\"strategy\":\"RAW_VALUE_STRATEGY\",\"edges\":[],\"tags\":[\"A\",\"B\",\"a\",\"b\"],\"originId\":\"someOrigin\",\"reason\":\"CRA relevant\",\"thresholds\":[{\"name\":\"warning\",\"value\":50},{\"name\":\"critical\",\"value\":90}],\"id\":\"cveId\"},\"plannedWeight\":1.0,\"actualWeight\":0.5}],\"id\":\"rootId\"},\"schemaVersion\":\"1.1.0\",\"timestamp\":\"${hierarchy.timestamp}\"}"
 
         kotlin.test.assertEquals(expected, jsonResult)
     }
@@ -105,7 +106,7 @@ class JsonKpiResultHierarchyTest {
                     result = KpiCalculationResult.Success(42),
                     strategy = KpiStrategyId.RAW_VALUE_STRATEGY,
                     edges = listOf(),
-                    thresholds = mapOf(),
+                    thresholds = listOf(),
                 ),
                 KpiResultNode(
                     typeId = "someId",
@@ -116,7 +117,7 @@ class JsonKpiResultHierarchyTest {
                     tags = setOf("A", "B", "a", "b", "A"),
                     originId = "someOrigin",
                     reason = "someReason",
-                    thresholds = mapOf("warning" to 50, "critical" to 90),
+                    thresholds = listOf(Threshold("warning", 50), Threshold("critical", 90)),
                 ),
                 KpiResultNode(
                     typeId = "someId",

--- a/model/src/test/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/JsonKpiResultHierarchyTest.kt
+++ b/model/src/test/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/JsonKpiResultHierarchyTest.kt
@@ -75,6 +75,7 @@ class JsonKpiResultHierarchyTest {
                                     tags = setOf("A", "B", "a", "b", "A"),
                                     originId = "someOrigin",
                                     reason = "CRA relevant",
+                                    thresholds = mapOf("warning" to 50, "critical" to 90)
                                 ),
                         )
                     ),
@@ -90,7 +91,7 @@ class JsonKpiResultHierarchyTest {
         // This implicitly asserts that KpiResultNode and KpiResultEdge get serialized to the
         // expected JSON too
         val expected =
-            "{\"root\":{\"typeId\":\"ROOT\",\"result\":{\"type\":\"de.fraunhofer.iem.spha.model.kpi.hierarchy.KpiCalculationResult.Success\",\"score\":100},\"strategy\":\"MAXIMUM_STRATEGY\",\"edges\":[{\"target\":{\"typeId\":\"CODE_VULNERABILITY_SCORE\",\"result\":{\"type\":\"de.fraunhofer.iem.spha.model.kpi.hierarchy.KpiCalculationResult.Success\",\"score\":100},\"strategy\":\"RAW_VALUE_STRATEGY\",\"edges\":[],\"tags\":[\"A\",\"B\",\"a\",\"b\"],\"originId\":\"someOrigin\",\"reason\":\"CRA relevant\",\"id\":\"cveId\"},\"plannedWeight\":1.0,\"actualWeight\":0.5}],\"id\":\"rootId\"},\"schemaVersion\":\"1.1.0\",\"timestamp\":\"${hierarchy.timestamp}\"}"
+            "{\"root\":{\"typeId\":\"ROOT\",\"result\":{\"type\":\"de.fraunhofer.iem.spha.model.kpi.hierarchy.KpiCalculationResult.Success\",\"score\":100},\"strategy\":\"MAXIMUM_STRATEGY\",\"edges\":[{\"target\":{\"typeId\":\"CODE_VULNERABILITY_SCORE\",\"result\":{\"type\":\"de.fraunhofer.iem.spha.model.kpi.hierarchy.KpiCalculationResult.Success\",\"score\":100},\"strategy\":\"RAW_VALUE_STRATEGY\",\"edges\":[],\"tags\":[\"A\",\"B\",\"a\",\"b\"],\"originId\":\"someOrigin\",\"reason\":\"CRA relevant\",\"thresholds\":{\"warning\":50,\"critical\":90},\"id\":\"cveId\"},\"plannedWeight\":1.0,\"actualWeight\":0.5}],\"id\":\"rootId\"},\"schemaVersion\":\"1.1.0\",\"timestamp\":\"${hierarchy.timestamp}\"}"
 
         kotlin.test.assertEquals(expected, jsonResult)
     }
@@ -104,6 +105,7 @@ class JsonKpiResultHierarchyTest {
                     result = KpiCalculationResult.Success(42),
                     strategy = KpiStrategyId.RAW_VALUE_STRATEGY,
                     edges = listOf(),
+                    thresholds = mapOf()
                 ),
                 KpiResultNode(
                     typeId = "someId",
@@ -114,6 +116,7 @@ class JsonKpiResultHierarchyTest {
                     tags = setOf("A", "B", "a", "b", "A"),
                     originId = "someOrigin",
                     reason = "someReason",
+                    thresholds = mapOf("warning" to 50, "critical" to 90)
                 ),
                 KpiResultNode(
                     typeId = "someId",

--- a/model/src/test/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/KpiHierarchyTest.kt
+++ b/model/src/test/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/KpiHierarchyTest.kt
@@ -75,7 +75,7 @@ class KpiHierarchyTest {
                 edges = listOf(),
                 tags = setOf("A", "B", "a", "b", "A"),
                 reason = "someReason",
-                thresholds = mapOf("warning" to 50, "critical" to 90)
+                thresholds = mapOf("warning" to 50, "critical" to 90),
             )
         assertEquals("ROOT", resultNode.typeId)
         assertEquals(KpiStrategyId.RAW_VALUE_STRATEGY, resultNode.strategy)

--- a/model/src/test/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/KpiHierarchyTest.kt
+++ b/model/src/test/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/KpiHierarchyTest.kt
@@ -75,11 +75,13 @@ class KpiHierarchyTest {
                 edges = listOf(),
                 tags = setOf("A", "B", "a", "b", "A"),
                 reason = "someReason",
+                thresholds = mapOf("warning" to 50, "critical" to 90)
             )
         assertEquals("ROOT", resultNode.typeId)
         assertEquals(KpiStrategyId.RAW_VALUE_STRATEGY, resultNode.strategy)
         assertEquals("someReason", resultNode.reason)
         assertEquals(setOf("A", "B", "a", "b"), resultNode.tags)
+        assertEquals(mapOf("warning" to 50, "critical" to 90), resultNode.thresholds)
     }
 
     @Test
@@ -91,7 +93,8 @@ class KpiHierarchyTest {
                 listOf(),
             )
 
-        assertEquals(setOf(), node.tags)
+        assertEquals(emptySet(), node.tags)
+        assertEquals(emptyMap(), node.thresholds)
         assertNull(node.reason)
     }
 }

--- a/model/src/test/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/KpiHierarchyTest.kt
+++ b/model/src/test/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/KpiHierarchyTest.kt
@@ -75,13 +75,16 @@ class KpiHierarchyTest {
                 edges = listOf(),
                 tags = setOf("A", "B", "a", "b", "A"),
                 reason = "someReason",
-                thresholds = mapOf("warning" to 50, "critical" to 90),
+                thresholds = listOf(Threshold("warning", 50), Threshold("critical", 90)),
             )
         assertEquals("ROOT", resultNode.typeId)
         assertEquals(KpiStrategyId.RAW_VALUE_STRATEGY, resultNode.strategy)
         assertEquals("someReason", resultNode.reason)
         assertEquals(setOf("A", "B", "a", "b"), resultNode.tags)
-        assertEquals(mapOf("warning" to 50, "critical" to 90), resultNode.thresholds)
+        assertEquals(
+            listOf(Threshold("warning", 50), Threshold("critical", 90)),
+            resultNode.thresholds,
+        )
     }
 
     @Test
@@ -94,7 +97,7 @@ class KpiHierarchyTest {
             )
 
         assertEquals(emptySet(), node.tags)
-        assertEquals(emptyMap(), node.thresholds)
+        assertEquals(listOf(), node.thresholds)
         assertNull(node.reason)
     }
 }

--- a/model/src/test/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/KpiResultNodeTest.kt
+++ b/model/src/test/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/KpiResultNodeTest.kt
@@ -24,7 +24,7 @@ class KpiResultNodeTest {
                 result = KpiCalculationResult.Success(100),
                 strategy = KpiStrategyId.WEIGHTED_AVERAGE_STRATEGY,
                 edges = emptyList(),
-                thresholds = mapOf(),
+                thresholds = listOf(),
             )
         val node2 =
             KpiResultNode(
@@ -32,7 +32,7 @@ class KpiResultNodeTest {
                 result = KpiCalculationResult.Success(100),
                 strategy = KpiStrategyId.WEIGHTED_AVERAGE_STRATEGY,
                 edges = emptyList(),
-                thresholds = mapOf(),
+                thresholds = listOf(),
             )
 
         // Verify that the IDs are different
@@ -43,7 +43,7 @@ class KpiResultNodeTest {
         assertEquals(KpiCalculationResult.Success(100), node1.result)
         assertEquals(KpiStrategyId.WEIGHTED_AVERAGE_STRATEGY, node1.strategy)
         assertEquals(emptyList(), node1.edges)
-        assertEquals(emptyMap(), node1.thresholds)
+        assertEquals(emptyList(), node1.thresholds)
         assertEquals(null, node1.originId)
         assertEquals(null, node1.reason)
     }
@@ -61,7 +61,7 @@ class KpiResultNodeTest {
                 id = customId,
                 originId = "origin-123",
                 reason = "test reason",
-                thresholds = mapOf("warning" to 50, "critical" to 90),
+                thresholds = listOf(Threshold("warning", 50), Threshold("critical", 90)),
             )
 
         // Verify that the custom ID is used
@@ -74,7 +74,7 @@ class KpiResultNodeTest {
         assertEquals(emptyList(), node.edges)
         assertEquals("origin-123", node.originId)
         assertEquals("test reason", node.reason)
-        assertEquals(mapOf("warning" to 50, "critical" to 90), node.thresholds)
+        assertEquals(listOf(Threshold("warning", 50), Threshold("critical", 90)), node.thresholds)
     }
 
     @Test
@@ -121,7 +121,7 @@ class KpiResultNodeTest {
                 id = "same-id",
                 originId = "origin-123",
                 reason = "test reason",
-                thresholds = mapOf("warning" to 50, "critical" to 90),
+                thresholds = listOf(Threshold("warning", 50), Threshold("critical", 90)),
             )
         val node2 =
             KpiResultNode(
@@ -132,7 +132,7 @@ class KpiResultNodeTest {
                 id = "same-id",
                 originId = "origin-123",
                 reason = "test reason",
-                thresholds = mapOf("warning" to 50, "critical" to 90),
+                thresholds = listOf(Threshold("warning", 50), Threshold("critical", 90)),
             )
 
         // IDs should be the same

--- a/model/src/test/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/KpiResultNodeTest.kt
+++ b/model/src/test/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/KpiResultNodeTest.kt
@@ -24,7 +24,7 @@ class KpiResultNodeTest {
                 result = KpiCalculationResult.Success(100),
                 strategy = KpiStrategyId.WEIGHTED_AVERAGE_STRATEGY,
                 edges = emptyList(),
-                thresholds = mapOf()
+                thresholds = mapOf(),
             )
         val node2 =
             KpiResultNode(
@@ -32,7 +32,7 @@ class KpiResultNodeTest {
                 result = KpiCalculationResult.Success(100),
                 strategy = KpiStrategyId.WEIGHTED_AVERAGE_STRATEGY,
                 edges = emptyList(),
-                thresholds = mapOf()
+                thresholds = mapOf(),
             )
 
         // Verify that the IDs are different
@@ -61,7 +61,7 @@ class KpiResultNodeTest {
                 id = customId,
                 originId = "origin-123",
                 reason = "test reason",
-                thresholds = mapOf("warning" to 50, "critical" to 90)
+                thresholds = mapOf("warning" to 50, "critical" to 90),
             )
 
         // Verify that the custom ID is used
@@ -121,7 +121,7 @@ class KpiResultNodeTest {
                 id = "same-id",
                 originId = "origin-123",
                 reason = "test reason",
-                thresholds = mapOf("warning" to 50, "critical" to 90)
+                thresholds = mapOf("warning" to 50, "critical" to 90),
             )
         val node2 =
             KpiResultNode(
@@ -132,7 +132,7 @@ class KpiResultNodeTest {
                 id = "same-id",
                 originId = "origin-123",
                 reason = "test reason",
-                thresholds = mapOf("warning" to 50, "critical" to 90)
+                thresholds = mapOf("warning" to 50, "critical" to 90),
             )
 
         // IDs should be the same

--- a/model/src/test/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/KpiResultNodeTest.kt
+++ b/model/src/test/kotlin/de/fraunhofer/iem/spha/model/kpi/hierarchy/KpiResultNodeTest.kt
@@ -24,6 +24,7 @@ class KpiResultNodeTest {
                 result = KpiCalculationResult.Success(100),
                 strategy = KpiStrategyId.WEIGHTED_AVERAGE_STRATEGY,
                 edges = emptyList(),
+                thresholds = mapOf()
             )
         val node2 =
             KpiResultNode(
@@ -31,6 +32,7 @@ class KpiResultNodeTest {
                 result = KpiCalculationResult.Success(100),
                 strategy = KpiStrategyId.WEIGHTED_AVERAGE_STRATEGY,
                 edges = emptyList(),
+                thresholds = mapOf()
             )
 
         // Verify that the IDs are different
@@ -41,6 +43,7 @@ class KpiResultNodeTest {
         assertEquals(KpiCalculationResult.Success(100), node1.result)
         assertEquals(KpiStrategyId.WEIGHTED_AVERAGE_STRATEGY, node1.strategy)
         assertEquals(emptyList(), node1.edges)
+        assertEquals(emptyMap(), node1.thresholds)
         assertEquals(null, node1.originId)
         assertEquals(null, node1.reason)
     }
@@ -58,6 +61,7 @@ class KpiResultNodeTest {
                 id = customId,
                 originId = "origin-123",
                 reason = "test reason",
+                thresholds = mapOf("warning" to 50, "critical" to 90)
             )
 
         // Verify that the custom ID is used
@@ -70,6 +74,7 @@ class KpiResultNodeTest {
         assertEquals(emptyList(), node.edges)
         assertEquals("origin-123", node.originId)
         assertEquals("test reason", node.reason)
+        assertEquals(mapOf("warning" to 50, "critical" to 90), node.thresholds)
     }
 
     @Test
@@ -116,6 +121,7 @@ class KpiResultNodeTest {
                 id = "same-id",
                 originId = "origin-123",
                 reason = "test reason",
+                thresholds = mapOf("warning" to 50, "critical" to 90)
             )
         val node2 =
             KpiResultNode(
@@ -126,6 +132,7 @@ class KpiResultNodeTest {
                 id = "same-id",
                 originId = "origin-123",
                 reason = "test reason",
+                thresholds = mapOf("warning" to 50, "critical" to 90)
             )
 
         // IDs should be the same


### PR DESCRIPTION
The result hierarchy re-uses the thresholds from the input hierarchy model.