### PR TITLE
correct trufflehog output format

### DIFF
--- a/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/ToolResultParser.kt
+++ b/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/ToolResultParser.kt
@@ -19,7 +19,7 @@ import de.fraunhofer.iem.spha.model.adapter.OsvScannerDto
 import de.fraunhofer.iem.spha.model.adapter.TlcDto
 import de.fraunhofer.iem.spha.model.adapter.ToolResult
 import de.fraunhofer.iem.spha.model.adapter.TrivyDtoV2
-import de.fraunhofer.iem.spha.model.adapter.TrufflehogDto
+import de.fraunhofer.iem.spha.model.adapter.TrufflehogReportDto
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.io.File
 import kotlinx.serialization.KSerializer
@@ -85,7 +85,7 @@ private class ToolProcessorImpl<T : ToolResult>(
                 ToolProcessorImpl(TrivyDtoV2.serializer(), jsonParser) {
                     TrivyAdapter.transformDataToKpi(it)
                 },
-                ToolProcessorImpl(TrufflehogDto.serializer(), jsonParser) {
+                ToolProcessorImpl(TrufflehogReportDto.serializer(), jsonParser) {
                     TrufflehogAdapter.transformDataToKpi(it)
                 },
                 ToolProcessorImpl(TlcDto.serializer(), jsonParser) {

--- a/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/tools/trufflehog/TrufflehogAdapter.kt
+++ b/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/tools/trufflehog/TrufflehogAdapter.kt
@@ -11,28 +11,25 @@ package de.fraunhofer.iem.spha.adapter.tools.trufflehog
 
 import de.fraunhofer.iem.spha.adapter.AdapterResult
 import de.fraunhofer.iem.spha.adapter.KpiAdapter
-import de.fraunhofer.iem.spha.model.adapter.TrufflehogDto
 import de.fraunhofer.iem.spha.model.adapter.TrufflehogReportDto
 import de.fraunhofer.iem.spha.model.kpi.KpiType
 import de.fraunhofer.iem.spha.model.kpi.RawValueKpi
 
-object TrufflehogAdapter : KpiAdapter<TrufflehogDto, TrufflehogReportDto>() {
+object TrufflehogAdapter : KpiAdapter<TrufflehogReportDto, TrufflehogReportDto>() {
 
     override fun transformDataToKpi(
-        vararg data: TrufflehogDto
+        vararg data: TrufflehogReportDto
     ): Collection<AdapterResult<TrufflehogReportDto>> {
-        return data
-            .flatMap { it.results }
-            .mapNotNull {
-                val verifiedSecrets = it.verifiedSecrets
-                if (verifiedSecrets == null) {
-                    return@mapNotNull null
-                }
-                val score = if (verifiedSecrets > 0) 0 else 100
-                AdapterResult.Success.Kpi(
-                    RawValueKpi(score = score, typeId = KpiType.SECRETS.name),
-                    origin = it,
-                )
+        return data.mapNotNull {
+            val verifiedSecrets = it.verifiedSecrets
+            if (verifiedSecrets == null) {
+                return@mapNotNull null
             }
+            val score = if (verifiedSecrets > 0) 0 else 100
+            AdapterResult.Success.Kpi(
+                RawValueKpi(score = score, typeId = KpiType.SECRETS.name),
+                origin = it,
+            )
+        }
     }
 }

--- a/adapter/src/test/resources/trufflehog-no-result.json
+++ b/adapter/src/test/resources/trufflehog-no-result.json
@@ -1,95 +1,19 @@
 {
-  "results": [
-    {
-      "level": "info-0",
-      "ts": "2024-11-19T13:14:04Z",
-      "logger": "trufflehog",
-      "msg": "running source",
-      "source_manager_worker_id": "JrTPL",
-      "with_units": true
-    },
-    {
-      "level": "info-0",
-      "ts": "2024-11-19T13:14:04Z",
-      "logger": "trufflehog",
-      "msg": "scanning repo",
-      "source_manager_worker_id": "JrTPL",
-      "unit_kind": "dir",
-      "unit": "/tmp/",
-      "repo": "https://github.com/fraunhofer-iem/spha-demo",
-      "head": "2f6d0a9ccb3211eff95126a7e36c68063c2432ce"
-    },
-    {
-      "SourceMetadata": {
-        "Data": {
-          "Git": {
-            "commit": "4a88901aaf9889a0672013bd4edfe8a99e290ab6",
-            "file": "src/main/java/com/example/demo/VulnerableJavaAppApplication.java",
-            "email": "Jan-Niclas Struewer \u003cj.n.struewer@gmail.com\u003e",
-            "repository": "https://github.com/fraunhofer-iem/spha-demo",
-            "timestamp": "2024-11-19 11:54:10 +0000",
-            "line": 9
-          }
-        }
-      },
-      "SourceID": 1,
-      "SourceType": 16,
-      "SourceName": "trufflehog - git",
-      "DetectorType": 895,
-      "DetectorName": "MongoDB",
-      "DetectorDescription": "MongoDB is a NoSQL database that uses a document-oriented data model. MongoDB credentials can be used to access and manipulate the database.",
-      "DecoderName": "PLAIN",
-      "Verified": false,
-      "VerificationError": "context deadline exceeded",
-      "Raw": "***agenda-live.mongo.cosmos.azure.com:10255/?appName=%40agenda-live\u0026maxIdleTimeMS=120000\u0026replicaSet=globaldb\u0026retryWrites=false\u0026ssl=true",
-      "RawV2": "",
-      "Redacted": "",
-      "ExtraData": {
-        "rotation_guide": "https://howtorotate.com/docs/tutorials/mongo/"
-      },
-      "StructuredData": null
-    },
-    {
-      "level": "info-0",
-      "ts": "2024-11-19T13:14:06Z",
-      "logger": "trufflehog",
-      "msg": "finished scanning",
-      "chunks": 63,
-      "bytes": 31905,
-      "verified_secrets": 0,
-      "unverified_secrets": 2,
-      "scan_duration": "2.020861236s",
-      "trufflehog_version": "3.83.7"
-    },
-    {
-      "SourceMetadata": {
-        "Data": {
-          "Git": {
-            "commit": "4a88901aaf9889a0672013bd4edfe8a99e290ab6",
-            "file": "src/main/resources/application.properties",
-            "email": "Jan-Niclas Struewer \u003cj.n.struewer@gmail.com\u003e",
-            "repository": "https://github.com/fraunhofer-iem/spha-demo",
-            "timestamp": "2024-11-19 11:54:10 +0000",
-            "line": 1
-          }
-        }
-      },
-      "SourceID": 1,
-      "SourceType": 16,
-      "SourceName": "trufflehog - git",
-      "DetectorType": 895,
-      "DetectorName": "MongoDB",
-      "DetectorDescription": "MongoDB is a NoSQL database that uses a document-oriented data model. MongoDB credentials can be used to access and manipulate the database.",
-      "DecoderName": "PLAIN",
-      "Verified": false,
-      "VerificationError": "context deadline exceeded",
-      "Raw": "***agenda-live.mongo.cosmos.azure.com:10255/?appName=%40agenda-live\u0026maxIdleTimeMS=120000\u0026replicaSet=globaldb\u0026retryWrites=false\u0026ssl=true",
-      "RawV2": "",
-      "Redacted": "",
-      "ExtraData": {
-        "rotation_guide": "https://howtorotate.com/docs/tutorials/mongo/"
-      },
-      "StructuredData": null
-    }
-  ]
+  "level": "info-0",
+  "ts": "2025-07-10T11:12:56+02:00",
+  "logger": "trufflehog",
+  "msg": "finished scanning",
+  "chunks": 14,
+  "bytes": 6959,
+  "verified_secrets": 0,
+  "unverified_secrets": 0,
+  "scan_duration": "1.802821959s",
+  "trufflehog_version": "3.89.2",
+  "verification_caching": {
+    "Hits": 0,
+    "Misses": 6,
+    "HitsWasted": 0,
+    "AttemptsSaved": 0,
+    "VerificationTimeSpentMS": 4639
+  }
 }

--- a/adapter/src/test/resources/trufflehog.json
+++ b/adapter/src/test/resources/trufflehog.json
@@ -1,95 +1,19 @@
 {
-  "results": [
-    {
-      "level": "info-0",
-      "ts": "2024-11-22T13:15:03Z",
-      "logger": "trufflehog",
-      "msg": "running source",
-      "source_manager_worker_id": "LTtXx",
-      "with_units": true
-    },
-    {
-      "level": "info-0",
-      "ts": "2024-11-22T13:15:03Z",
-      "logger": "trufflehog",
-      "msg": "scanning repo",
-      "source_manager_worker_id": "LTtXx",
-      "unit_kind": "dir",
-      "unit": "/tmp/",
-      "repo": "https://github.com/fraunhofer-iem/spha-demo",
-      "head": "0e9b0b3e2d4587b7c5cba541f746e947d51d9842"
-    },
-    {
-      "SourceMetadata": {
-        "Data": {
-          "Git": {
-            "commit": "4a88901aaf9889a0672013bd4edfe8a99e290ab6",
-            "file": "src/main/java/com/example/demo/VulnerableJavaAppApplication.java",
-            "email": "Jan-Niclas Struewer <j.n.struewer@gmail.com>",
-            "repository": "https://github.com/fraunhofer-iem/spha-demo",
-            "timestamp": "2024-11-19 11:54:10 +0000",
-            "line": 9
-          }
-        }
-      },
-      "SourceID": 1,
-      "SourceType": 16,
-      "SourceName": "trufflehog - git",
-      "DetectorType": 895,
-      "DetectorName": "MongoDB",
-      "DetectorDescription": "MongoDB is a NoSQL database that uses a document-oriented data model. MongoDB credentials can be used to access and manipulate the database.",
-      "DecoderName": "PLAIN",
-      "Verified": false,
-      "VerificationError": "context deadline exceeded",
-      "Raw": "***agenda-live.mongo.cosmos.azure.com:10255/?appName=%40agenda-live&maxIdleTimeMS=120000&replicaSet=globaldb&retryWrites=false&ssl=true",
-      "RawV2": "",
-      "Redacted": "",
-      "ExtraData": {
-        "rotation_guide": "https://howtorotate.com/docs/tutorials/mongo/"
-      },
-      "StructuredData": null
-    },
-    {
-      "SourceMetadata": {
-        "Data": {
-          "Git": {
-            "commit": "4a88901aaf9889a0672013bd4edfe8a99e290ab6",
-            "file": "src/main/resources/application.properties",
-            "email": "Jan-Niclas Struewer <j.n.struewer@gmail.com>",
-            "repository": "https://github.com/fraunhofer-iem/spha-demo",
-            "timestamp": "2024-11-19 11:54:10 +0000",
-            "line": 1
-          }
-        }
-      },
-      "SourceID": 1,
-      "SourceType": 16,
-      "SourceName": "trufflehog - git",
-      "DetectorType": 895,
-      "DetectorName": "MongoDB",
-      "DetectorDescription": "MongoDB is a NoSQL database that uses a document-oriented data model. MongoDB credentials can be used to access and manipulate the database.",
-      "DecoderName": "PLAIN",
-      "Verified": false,
-      "VerificationError": "context deadline exceeded",
-      "Raw": "***agenda-live.mongo.cosmos.azure.com:10255/?appName=%40agenda-live&maxIdleTimeMS=120000&replicaSet=globaldb&retryWrites=false&ssl=true",
-      "RawV2": "",
-      "Redacted": "",
-      "ExtraData": {
-        "rotation_guide": "https://howtorotate.com/docs/tutorials/mongo/"
-      },
-      "StructuredData": null
-    },
-    {
-      "level": "info-0",
-      "ts": "2024-11-22T13:15:08Z",
-      "logger": "trufflehog",
-      "msg": "finished scanning",
-      "chunks": 77,
-      "bytes": 35194,
-      "verified_secrets": 1,
-      "unverified_secrets": 2,
-      "scan_duration": "5.024563541s",
-      "trufflehog_version": "3.84.0"
-    }
-  ]
+  "level": "info-0",
+  "ts": "2025-07-10T11:12:56+02:00",
+  "logger": "trufflehog",
+  "msg": "finished scanning",
+  "chunks": 14,
+  "bytes": 6959,
+  "verified_secrets": 4,
+  "unverified_secrets": 0,
+  "scan_duration": "1.802821959s",
+  "trufflehog_version": "3.89.2",
+  "verification_caching": {
+    "Hits": 0,
+    "Misses": 6,
+    "HitsWasted": 0,
+    "AttemptsSaved": 0,
+    "VerificationTimeSpentMS": 4639
+  }
 }

--- a/model/src/main/kotlin/de/fraunhofer/iem/spha/model/adapter/AdapterToolResult.kt
+++ b/model/src/main/kotlin/de/fraunhofer/iem/spha/model/adapter/AdapterToolResult.kt
@@ -9,6 +9,8 @@
 
 package de.fraunhofer.iem.spha.model.adapter
 
+import kotlinx.serialization.Serializable
+
 /**
  * Represents a sealed interface serving as a marker for various origin-related data types. It is
  * designed to model and group different implementations that signify the origin of specific data or
@@ -17,4 +19,4 @@ package de.fraunhofer.iem.spha.model.adapter
  * Implementations of this interface may vary based on their usage. For instance, they could
  * represent the origin of analysis results or details from different tools.
  */
-sealed interface Origin
+@Serializable sealed interface Origin

--- a/model/src/main/kotlin/de/fraunhofer/iem/spha/model/adapter/Trufflehog.kt
+++ b/model/src/main/kotlin/de/fraunhofer/iem/spha/model/adapter/Trufflehog.kt
@@ -12,18 +12,12 @@ package de.fraunhofer.iem.spha.model.adapter
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-@Serializable data class TrufflehogDto(val results: List<TrufflehogReportDto>) : ToolResult
-
 @Serializable
 data class TrufflehogReportDto(
-    val level: String?,
-    val ts: String?,
-    val logger: String?,
-    val msg: String?,
     val chunks: Int?,
     val bytes: Int?,
     @SerialName("verified_secrets") val verifiedSecrets: Int?,
     @SerialName("unverified_secrets") val unverifiedSecrets: Int?,
     @SerialName("scan_duration") val scanDuration: String?,
     @SerialName("trufflehog_version") val trufflehogVersion: String?,
-) : Origin
+) : ToolResult, Origin


### PR DESCRIPTION
This PR corrects / simplifies the trufflehog tool format
Further it adds the (@)Serializable annotation to the Origin interface to enable clients to serialize all Origin objects without further effort