### PR TITLE
Refactor and enhance adapter data models and processing logic

### DIFF
--- a/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/KpiAdapter.kt
+++ b/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/KpiAdapter.kt
@@ -12,7 +12,6 @@ package de.fraunhofer.iem.spha.adapter
 import de.fraunhofer.iem.spha.model.adapter.Origin
 import de.fraunhofer.iem.spha.model.adapter.ToolResult
 import de.fraunhofer.iem.spha.model.kpi.RawValueKpi
-import de.fraunhofer.iem.spha.model.kpi.hierarchy.MetaInfo
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.io.InputStream
 import kotlinx.serialization.ExperimentalSerializationApi
@@ -33,7 +32,7 @@ abstract class KpiAdapter<T : ToolResult, O : Origin> {
 
     protected val logger = KotlinLogging.logger {}
 
-    abstract fun transformDataToKpi(vararg data: T): Collection<TransformationResult<O>>
+    abstract fun transformDataToKpi(vararg data: T): AdapterResult<O>
 
     @OptIn(ExperimentalSerializationApi::class)
     fun dtoFromJson(jsonData: InputStream, deserializer: KSerializer<T>): T {
@@ -41,7 +40,12 @@ abstract class KpiAdapter<T : ToolResult, O : Origin> {
     }
 }
 
-data class AdapterResult<T : Origin>(val metaInfo: MetaInfo, val transformationResults: Collection<TransformationResult<T>>)
+data class ToolInfo(val name: String, val description: String, val version: String? = null)
+
+data class AdapterResult<T : Origin>(
+    val toolInfo: ToolInfo? = null,
+    val transformationResults: Collection<TransformationResult<T>> = emptyList(),
+)
 
 sealed class TransformationResult<out T : Origin> {
     /**

--- a/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/KpiAdapter.kt
+++ b/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/KpiAdapter.kt
@@ -16,6 +16,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import java.io.InputStream
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromStream
 
@@ -40,13 +41,16 @@ abstract class KpiAdapter<T : ToolResult, O : Origin> {
     }
 }
 
+@Serializable
 data class ToolInfo(val name: String, val description: String, val version: String? = null)
 
+@Serializable
 data class AdapterResult<T : Origin>(
     val toolInfo: ToolInfo? = null,
     val transformationResults: Collection<TransformationResult<T>> = emptyList(),
 )
 
+@Serializable
 sealed class TransformationResult<out T : Origin> {
     /**
      * @param origin describes the data that the RawValueKpi was created from. If, for some reason,

--- a/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/ToolResultParser.kt
+++ b/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/ToolResultParser.kt
@@ -35,7 +35,7 @@ private interface ToolProcessor {
      * Tries to process the given JSON content.
      *
      * @param content The JSON string to process.
-     * @return A list of `AdapterResult<Origin>` on success, or `null` if the content does not match
+     * @return A list of `TransformationResult<Origin>` on success, or `null` if the content does not match
      *   this processor's format.
      * @throws Exception for unexpected errors during transformation logic.
      */
@@ -53,7 +53,7 @@ private interface ToolProcessor {
 private class ToolProcessorImpl<T : ToolResult>(
     private val serializer: KSerializer<T>,
     private val jsonParser: Json,
-    private val transform: (T) -> Collection<TransformationResult<Origin>>,
+    private val transform: (T) -> AdapterResult<*>,
 ) : ToolProcessor {
 
     override val name: String
@@ -62,7 +62,7 @@ private class ToolProcessorImpl<T : ToolResult>(
     override fun tryProcess(content: String): Collection<TransformationResult<Origin>>? {
         return try {
             val resultObject = jsonParser.decodeFromString(serializer, content)
-            transform(resultObject)
+            transform(resultObject).transformationResults
         } catch (_: SerializationException) {
             // This is an expected failure when the JSON does not match the DTO.
             // Return null to signal that the next processor should be tried.

--- a/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/kpis/vcs/VcsAdapter.kt
+++ b/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/kpis/vcs/VcsAdapter.kt
@@ -9,7 +9,7 @@
 
 package de.fraunhofer.iem.spha.adapter.kpis.vcs
 
-import de.fraunhofer.iem.spha.adapter.AdapterResult
+import de.fraunhofer.iem.spha.adapter.TransformationResult
 import de.fraunhofer.iem.spha.adapter.KpiAdapter
 import de.fraunhofer.iem.spha.model.adapter.RepositoryDetails
 import de.fraunhofer.iem.spha.model.kpi.KpiType
@@ -19,25 +19,25 @@ object VcsAdapter : KpiAdapter<RepositoryDetails, RepositoryDetails>() {
 
     override fun transformDataToKpi(
         vararg data: RepositoryDetails
-    ): Collection<AdapterResult<RepositoryDetails>> {
+    ): Collection<TransformationResult<RepositoryDetails>> {
 
         return data.flatMap { repoDetailsDto ->
             return@flatMap listOf(
-                AdapterResult.Success.Kpi(
+                TransformationResult.Success.Kpi(
                     RawValueKpi(
                         typeId = KpiType.NUMBER_OF_COMMITS.name,
                         score = repoDetailsDto.numberOfCommits,
                     ),
                     origin = repoDetailsDto,
                 ),
-                AdapterResult.Success.Kpi(
+                TransformationResult.Success.Kpi(
                     RawValueKpi(
                         typeId = KpiType.NUMBER_OF_SIGNED_COMMITS.name,
                         score = repoDetailsDto.numberOfSignedCommits,
                     ),
                     origin = repoDetailsDto,
                 ),
-                AdapterResult.Success.Kpi(
+                TransformationResult.Success.Kpi(
                     RawValueKpi(
                         typeId = KpiType.IS_DEFAULT_BRANCH_PROTECTED.name,
                         score = if (repoDetailsDto.isDefaultBranchProtected) 100 else 0,

--- a/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/kpis/vcs/VcsAdapter.kt
+++ b/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/kpis/vcs/VcsAdapter.kt
@@ -9,8 +9,10 @@
 
 package de.fraunhofer.iem.spha.adapter.kpis.vcs
 
-import de.fraunhofer.iem.spha.adapter.TransformationResult
+import de.fraunhofer.iem.spha.adapter.AdapterResult
 import de.fraunhofer.iem.spha.adapter.KpiAdapter
+import de.fraunhofer.iem.spha.adapter.ToolInfo
+import de.fraunhofer.iem.spha.adapter.TransformationResult
 import de.fraunhofer.iem.spha.model.adapter.RepositoryDetails
 import de.fraunhofer.iem.spha.model.kpi.KpiType
 import de.fraunhofer.iem.spha.model.kpi.RawValueKpi
@@ -19,32 +21,38 @@ object VcsAdapter : KpiAdapter<RepositoryDetails, RepositoryDetails>() {
 
     override fun transformDataToKpi(
         vararg data: RepositoryDetails
-    ): Collection<TransformationResult<RepositoryDetails>> {
+    ): AdapterResult<RepositoryDetails> {
 
-        return data.flatMap { repoDetailsDto ->
-            return@flatMap listOf(
-                TransformationResult.Success.Kpi(
-                    RawValueKpi(
-                        typeId = KpiType.NUMBER_OF_COMMITS.name,
-                        score = repoDetailsDto.numberOfCommits,
+        val transformedData =
+            data.flatMap { repoDetailsDto ->
+                return@flatMap listOf(
+                    TransformationResult.Success.Kpi(
+                        RawValueKpi(
+                            typeId = KpiType.NUMBER_OF_COMMITS.name,
+                            score = repoDetailsDto.numberOfCommits,
+                        ),
+                        origin = repoDetailsDto,
                     ),
-                    origin = repoDetailsDto,
-                ),
-                TransformationResult.Success.Kpi(
-                    RawValueKpi(
-                        typeId = KpiType.NUMBER_OF_SIGNED_COMMITS.name,
-                        score = repoDetailsDto.numberOfSignedCommits,
+                    TransformationResult.Success.Kpi(
+                        RawValueKpi(
+                            typeId = KpiType.NUMBER_OF_SIGNED_COMMITS.name,
+                            score = repoDetailsDto.numberOfSignedCommits,
+                        ),
+                        origin = repoDetailsDto,
                     ),
-                    origin = repoDetailsDto,
-                ),
-                TransformationResult.Success.Kpi(
-                    RawValueKpi(
-                        typeId = KpiType.IS_DEFAULT_BRANCH_PROTECTED.name,
-                        score = if (repoDetailsDto.isDefaultBranchProtected) 100 else 0,
+                    TransformationResult.Success.Kpi(
+                        RawValueKpi(
+                            typeId = KpiType.IS_DEFAULT_BRANCH_PROTECTED.name,
+                            score = if (repoDetailsDto.isDefaultBranchProtected) 100 else 0,
+                        ),
+                        origin = repoDetailsDto,
                     ),
-                    origin = repoDetailsDto,
-                ),
-            )
-        }
+                )
+            }
+
+        return AdapterResult(
+            toolInfo = ToolInfo(name = "VCS", description = "Version Control System"),
+            transformationResults = transformedData,
+        )
     }
 }

--- a/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/tools/osv/OsvAdapter.kt
+++ b/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/tools/osv/OsvAdapter.kt
@@ -9,9 +9,11 @@
 
 package de.fraunhofer.iem.spha.adapter.tools.osv
 
-import de.fraunhofer.iem.spha.adapter.TransformationResult
+import de.fraunhofer.iem.spha.adapter.AdapterResult
 import de.fraunhofer.iem.spha.adapter.ErrorType
 import de.fraunhofer.iem.spha.adapter.KpiAdapter
+import de.fraunhofer.iem.spha.adapter.ToolInfo
+import de.fraunhofer.iem.spha.adapter.TransformationResult
 import de.fraunhofer.iem.spha.adapter.kpis.cve.transformVulnerabilityToKpi
 import de.fraunhofer.iem.spha.model.adapter.OsvScannerDto
 import de.fraunhofer.iem.spha.model.adapter.OsvVulnerabilityDto
@@ -22,28 +24,40 @@ object OsvAdapter : KpiAdapter<OsvScannerDto, OsvVulnerabilityDto>() {
 
     override fun transformDataToKpi(
         vararg data: OsvScannerDto
-    ): Collection<TransformationResult<OsvVulnerabilityDto>> {
-        return data
-            .flatMap { it.results }
-            .flatMap { it.packages }
-            .flatMap { pkg ->
-                pkg.vulnerabilities.map { osvVuln ->
-                    // If severity is null or empty, return an error
-                    val severityList =
-                        osvVuln.severity.mapNotNull { CvssVector.parseVector(it.score)?.baseScore }
-                    if (severityList.isEmpty()) {
-                        return@map TransformationResult.Error(ErrorType.DATA_VALIDATION_ERROR)
+    ): AdapterResult<OsvVulnerabilityDto> {
+        val transformedData =
+            data
+                .flatMap { it.results }
+                .flatMap { it.packages }
+                .flatMap { pkg ->
+                    pkg.vulnerabilities.map { osvVuln ->
+                        // If severity is null or empty, return an error
+                        val severityList =
+                            osvVuln.severity.mapNotNull {
+                                CvssVector.parseVector(it.score)?.baseScore
+                            }
+                        if (severityList.isEmpty()) {
+                            return@map TransformationResult.Error(ErrorType.DATA_VALIDATION_ERROR)
+                        }
+
+                        val score =
+                            severityList.maxOrNull()
+                                ?: return@map TransformationResult.Error(
+                                    ErrorType.DATA_VALIDATION_ERROR
+                                )
+
+                        val rawValueKpi =
+                            transformVulnerabilityToKpi(score, KpiType.CODE_VULNERABILITY_SCORE)
+                                ?: return@map TransformationResult.Error(
+                                    ErrorType.DATA_VALIDATION_ERROR
+                                )
+                        return@map TransformationResult.Success.Kpi(rawValueKpi, osvVuln)
                     }
-
-                    val score =
-                        severityList.maxOrNull()
-                            ?: return@map TransformationResult.Error(ErrorType.DATA_VALIDATION_ERROR)
-
-                    val rawValueKpi =
-                        transformVulnerabilityToKpi(score, KpiType.CODE_VULNERABILITY_SCORE)
-                            ?: return@map TransformationResult.Error(ErrorType.DATA_VALIDATION_ERROR)
-                    return@map TransformationResult.Success.Kpi(rawValueKpi, osvVuln)
                 }
-            }
+
+        return AdapterResult(
+            toolInfo = ToolInfo(name = "OSV", description = "Open Source Vulnerability Scanner"),
+            transformationResults = transformedData,
+        )
     }
 }

--- a/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/tools/osv/OsvAdapter.kt
+++ b/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/tools/osv/OsvAdapter.kt
@@ -9,7 +9,7 @@
 
 package de.fraunhofer.iem.spha.adapter.tools.osv
 
-import de.fraunhofer.iem.spha.adapter.AdapterResult
+import de.fraunhofer.iem.spha.adapter.TransformationResult
 import de.fraunhofer.iem.spha.adapter.ErrorType
 import de.fraunhofer.iem.spha.adapter.KpiAdapter
 import de.fraunhofer.iem.spha.adapter.kpis.cve.transformVulnerabilityToKpi
@@ -22,7 +22,7 @@ object OsvAdapter : KpiAdapter<OsvScannerDto, OsvVulnerabilityDto>() {
 
     override fun transformDataToKpi(
         vararg data: OsvScannerDto
-    ): Collection<AdapterResult<OsvVulnerabilityDto>> {
+    ): Collection<TransformationResult<OsvVulnerabilityDto>> {
         return data
             .flatMap { it.results }
             .flatMap { it.packages }
@@ -32,17 +32,17 @@ object OsvAdapter : KpiAdapter<OsvScannerDto, OsvVulnerabilityDto>() {
                     val severityList =
                         osvVuln.severity.mapNotNull { CvssVector.parseVector(it.score)?.baseScore }
                     if (severityList.isEmpty()) {
-                        return@map AdapterResult.Error(ErrorType.DATA_VALIDATION_ERROR)
+                        return@map TransformationResult.Error(ErrorType.DATA_VALIDATION_ERROR)
                     }
 
                     val score =
                         severityList.maxOrNull()
-                            ?: return@map AdapterResult.Error(ErrorType.DATA_VALIDATION_ERROR)
+                            ?: return@map TransformationResult.Error(ErrorType.DATA_VALIDATION_ERROR)
 
                     val rawValueKpi =
                         transformVulnerabilityToKpi(score, KpiType.CODE_VULNERABILITY_SCORE)
-                            ?: return@map AdapterResult.Error(ErrorType.DATA_VALIDATION_ERROR)
-                    return@map AdapterResult.Success.Kpi(rawValueKpi, osvVuln)
+                            ?: return@map TransformationResult.Error(ErrorType.DATA_VALIDATION_ERROR)
+                    return@map TransformationResult.Success.Kpi(rawValueKpi, osvVuln)
                 }
             }
     }

--- a/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/tools/tlc/TlcAdapter.kt
+++ b/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/tools/tlc/TlcAdapter.kt
@@ -9,7 +9,7 @@
 
 package de.fraunhofer.iem.spha.adapter.tools.tlc
 
-import de.fraunhofer.iem.spha.adapter.AdapterResult
+import de.fraunhofer.iem.spha.adapter.TransformationResult
 import de.fraunhofer.iem.spha.adapter.ErrorType
 import de.fraunhofer.iem.spha.adapter.KpiAdapter
 import de.fraunhofer.iem.spha.model.adapter.ComponentLag
@@ -20,14 +20,14 @@ import de.fraunhofer.iem.spha.model.kpi.RawValueKpi
 
 object TlcAdapter : KpiAdapter<TlcDto, TlcOrigin>() {
 
-    override fun transformDataToKpi(vararg data: TlcDto): Collection<AdapterResult<TlcOrigin>> =
+    override fun transformDataToKpi(vararg data: TlcDto): Collection<TransformationResult<TlcOrigin>> =
         data.flatMap { tlcDto ->
             val baseKpis = createBaseKpis(tlcDto)
             val componentKpis = createComponentKpis(tlcDto)
             baseKpis + componentKpis
         }
 
-    private fun createBaseKpis(tlcDto: TlcDto): List<AdapterResult<TlcOrigin>> {
+    private fun createBaseKpis(tlcDto: TlcDto): List<TransformationResult<TlcOrigin>> {
         val sections =
             listOf(
                 tlcDto.transitiveOptional to KpiType.HIGHEST_LIB_DAYS_DEV_TRANSITIVE,
@@ -39,17 +39,17 @@ object TlcAdapter : KpiAdapter<TlcDto, TlcOrigin>() {
         return sections.map { (tlc, kpiType) ->
             val highestLibyearsComponent = tlc.componentHighestLibdays
             if (highestLibyearsComponent != null) {
-                AdapterResult.Success.Kpi(
+                TransformationResult.Success.Kpi(
                     RawValueKpi(typeId = kpiType.name, score = tlc.highestLibdays.toInt()),
                     highestLibyearsComponent,
                 )
             } else {
-                AdapterResult.Error(ErrorType.DATA_VALIDATION_ERROR)
+                TransformationResult.Error(ErrorType.DATA_VALIDATION_ERROR)
             }
         }
     }
 
-    private fun createComponentKpis(tlcDto: TlcDto): List<AdapterResult.Success.Kpi<ComponentLag>> {
+    private fun createComponentKpis(tlcDto: TlcDto): List<TransformationResult.Success.Kpi<ComponentLag>> {
         val sections =
             listOf(
                 tlcDto.transitiveOptional to KpiType.TECHNICAL_LAG_DEV_TRANSITIVE_COMPONENT,
@@ -66,8 +66,8 @@ object TlcAdapter : KpiAdapter<TlcDto, TlcOrigin>() {
     private fun createComponentKpi(
         compLag: ComponentLag,
         kpiType: KpiType,
-    ): AdapterResult.Success.Kpi<ComponentLag> =
-        AdapterResult.Success.Kpi(
+    ): TransformationResult.Success.Kpi<ComponentLag> =
+        TransformationResult.Success.Kpi(
             RawValueKpi(typeId = kpiType.name, score = compLag.technicalLag.libdays.toInt()),
             compLag,
         )

--- a/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/tools/tlc/TlcAdapter.kt
+++ b/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/tools/tlc/TlcAdapter.kt
@@ -9,9 +9,11 @@
 
 package de.fraunhofer.iem.spha.adapter.tools.tlc
 
-import de.fraunhofer.iem.spha.adapter.TransformationResult
+import de.fraunhofer.iem.spha.adapter.AdapterResult
 import de.fraunhofer.iem.spha.adapter.ErrorType
 import de.fraunhofer.iem.spha.adapter.KpiAdapter
+import de.fraunhofer.iem.spha.adapter.ToolInfo
+import de.fraunhofer.iem.spha.adapter.TransformationResult
 import de.fraunhofer.iem.spha.model.adapter.ComponentLag
 import de.fraunhofer.iem.spha.model.adapter.TlcDto
 import de.fraunhofer.iem.spha.model.adapter.TlcOrigin
@@ -20,12 +22,23 @@ import de.fraunhofer.iem.spha.model.kpi.RawValueKpi
 
 object TlcAdapter : KpiAdapter<TlcDto, TlcOrigin>() {
 
-    override fun transformDataToKpi(vararg data: TlcDto): Collection<TransformationResult<TlcOrigin>> =
-        data.flatMap { tlcDto ->
-            val baseKpis = createBaseKpis(tlcDto)
-            val componentKpis = createComponentKpis(tlcDto)
-            baseKpis + componentKpis
-        }
+    override fun transformDataToKpi(vararg data: TlcDto): AdapterResult<TlcOrigin> {
+        val transformedData =
+            data.flatMap { tlcDto ->
+                val baseKpis = createBaseKpis(tlcDto)
+                val componentKpis = createComponentKpis(tlcDto)
+                baseKpis + componentKpis
+            }
+
+        return AdapterResult(
+            toolInfo =
+                ToolInfo(
+                    "Technical Lag Analyzer",
+                    "Calculates technical lag based on a project's SBOM",
+                ),
+            transformationResults = transformedData,
+        )
+    }
 
     private fun createBaseKpis(tlcDto: TlcDto): List<TransformationResult<TlcOrigin>> {
         val sections =
@@ -49,7 +62,9 @@ object TlcAdapter : KpiAdapter<TlcDto, TlcOrigin>() {
         }
     }
 
-    private fun createComponentKpis(tlcDto: TlcDto): List<TransformationResult.Success.Kpi<ComponentLag>> {
+    private fun createComponentKpis(
+        tlcDto: TlcDto
+    ): List<TransformationResult.Success.Kpi<ComponentLag>> {
         val sections =
             listOf(
                 tlcDto.transitiveOptional to KpiType.TECHNICAL_LAG_DEV_TRANSITIVE_COMPONENT,

--- a/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/tools/trivy/TrivyAdapter.kt
+++ b/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/tools/trivy/TrivyAdapter.kt
@@ -9,7 +9,7 @@
 
 package de.fraunhofer.iem.spha.adapter.tools.trivy
 
-import de.fraunhofer.iem.spha.adapter.AdapterResult
+import de.fraunhofer.iem.spha.adapter.TransformationResult
 import de.fraunhofer.iem.spha.adapter.ErrorType
 import de.fraunhofer.iem.spha.adapter.KpiAdapter
 import de.fraunhofer.iem.spha.adapter.kpis.cve.transformVulnerabilityToKpi
@@ -24,21 +24,21 @@ object TrivyAdapter : KpiAdapter<TrivyDtoV2, TrivyVulnerabilityDto>() {
 
     override fun transformDataToKpi(
         vararg data: TrivyDtoV2
-    ): Collection<AdapterResult<TrivyVulnerabilityDto>> {
+    ): Collection<TransformationResult<TrivyVulnerabilityDto>> {
         return data
             .flatMap { it.results }
             .flatMap { it.vulnerabilities }
             .map { trivyVuln ->
                 val score = getHighestCvssScore(trivyVuln)
                 if (score == null) {
-                    return@map AdapterResult.Error(ErrorType.DATA_VALIDATION_ERROR)
+                    return@map TransformationResult.Error(ErrorType.DATA_VALIDATION_ERROR)
                 }
                 val rawValueKpi =
                     transformVulnerabilityToKpi(score, KpiType.CONTAINER_VULNERABILITY_SCORE)
                 if (rawValueKpi == null) {
-                    return@map AdapterResult.Error(ErrorType.DATA_VALIDATION_ERROR)
+                    return@map TransformationResult.Error(ErrorType.DATA_VALIDATION_ERROR)
                 }
-                return@map AdapterResult.Success.Kpi(rawValueKpi, trivyVuln)
+                return@map TransformationResult.Success.Kpi(rawValueKpi, trivyVuln)
             }
     }
 

--- a/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/tools/trivy/TrivyAdapter.kt
+++ b/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/tools/trivy/TrivyAdapter.kt
@@ -9,9 +9,11 @@
 
 package de.fraunhofer.iem.spha.adapter.tools.trivy
 
-import de.fraunhofer.iem.spha.adapter.TransformationResult
+import de.fraunhofer.iem.spha.adapter.AdapterResult
 import de.fraunhofer.iem.spha.adapter.ErrorType
 import de.fraunhofer.iem.spha.adapter.KpiAdapter
+import de.fraunhofer.iem.spha.adapter.ToolInfo
+import de.fraunhofer.iem.spha.adapter.TransformationResult
 import de.fraunhofer.iem.spha.adapter.kpis.cve.transformVulnerabilityToKpi
 import de.fraunhofer.iem.spha.model.adapter.CVSSData
 import de.fraunhofer.iem.spha.model.adapter.TrivyDtoV2
@@ -22,24 +24,28 @@ import kotlinx.serialization.json.decodeFromJsonElement
 
 object TrivyAdapter : KpiAdapter<TrivyDtoV2, TrivyVulnerabilityDto>() {
 
-    override fun transformDataToKpi(
-        vararg data: TrivyDtoV2
-    ): Collection<TransformationResult<TrivyVulnerabilityDto>> {
-        return data
-            .flatMap { it.results }
-            .flatMap { it.vulnerabilities }
-            .map { trivyVuln ->
-                val score = getHighestCvssScore(trivyVuln)
-                if (score == null) {
-                    return@map TransformationResult.Error(ErrorType.DATA_VALIDATION_ERROR)
+    override fun transformDataToKpi(vararg data: TrivyDtoV2): AdapterResult<TrivyVulnerabilityDto> {
+        val transformedData =
+            data
+                .flatMap { it.results }
+                .flatMap { it.vulnerabilities }
+                .map { trivyVuln ->
+                    val score =
+                        getHighestCvssScore(trivyVuln)
+                            ?: return@map TransformationResult.Error(
+                                ErrorType.DATA_VALIDATION_ERROR
+                            )
+                    val rawValueKpi =
+                        transformVulnerabilityToKpi(score, KpiType.CONTAINER_VULNERABILITY_SCORE)
+                            ?: return@map TransformationResult.Error(
+                                ErrorType.DATA_VALIDATION_ERROR
+                            )
+                    return@map TransformationResult.Success.Kpi(rawValueKpi, trivyVuln)
                 }
-                val rawValueKpi =
-                    transformVulnerabilityToKpi(score, KpiType.CONTAINER_VULNERABILITY_SCORE)
-                if (rawValueKpi == null) {
-                    return@map TransformationResult.Error(ErrorType.DATA_VALIDATION_ERROR)
-                }
-                return@map TransformationResult.Success.Kpi(rawValueKpi, trivyVuln)
-            }
+        return AdapterResult(
+            toolInfo = ToolInfo(name = "Trivy", description = "Container Image Scanner"),
+            transformationResults = transformedData,
+        )
     }
 
     private fun getHighestCvssScore(vulnerability: TrivyVulnerabilityDto): Double? {

--- a/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/tools/trufflehog/TrufflehogAdapter.kt
+++ b/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/tools/trufflehog/TrufflehogAdapter.kt
@@ -9,7 +9,7 @@
 
 package de.fraunhofer.iem.spha.adapter.tools.trufflehog
 
-import de.fraunhofer.iem.spha.adapter.AdapterResult
+import de.fraunhofer.iem.spha.adapter.TransformationResult
 import de.fraunhofer.iem.spha.adapter.KpiAdapter
 import de.fraunhofer.iem.spha.model.adapter.TrufflehogReportDto
 import de.fraunhofer.iem.spha.model.kpi.KpiType
@@ -19,14 +19,14 @@ object TrufflehogAdapter : KpiAdapter<TrufflehogReportDto, TrufflehogReportDto>(
 
     override fun transformDataToKpi(
         vararg data: TrufflehogReportDto
-    ): Collection<AdapterResult<TrufflehogReportDto>> {
+    ): Collection<TransformationResult<TrufflehogReportDto>> {
         return data.mapNotNull {
             val verifiedSecrets = it.verifiedSecrets
             if (verifiedSecrets == null) {
                 return@mapNotNull null
             }
             val score = if (verifiedSecrets > 0) 0 else 100
-            AdapterResult.Success.Kpi(
+            TransformationResult.Success.Kpi(
                 RawValueKpi(score = score, typeId = KpiType.SECRETS.name),
                 origin = it,
             )

--- a/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/tools/trufflehog/TrufflehogAdapter.kt
+++ b/adapter/src/main/kotlin/de/fraunhofer/iem/spha/adapter/tools/trufflehog/TrufflehogAdapter.kt
@@ -9,8 +9,10 @@
 
 package de.fraunhofer.iem.spha.adapter.tools.trufflehog
 
-import de.fraunhofer.iem.spha.adapter.TransformationResult
+import de.fraunhofer.iem.spha.adapter.AdapterResult
 import de.fraunhofer.iem.spha.adapter.KpiAdapter
+import de.fraunhofer.iem.spha.adapter.ToolInfo
+import de.fraunhofer.iem.spha.adapter.TransformationResult
 import de.fraunhofer.iem.spha.model.adapter.TrufflehogReportDto
 import de.fraunhofer.iem.spha.model.kpi.KpiType
 import de.fraunhofer.iem.spha.model.kpi.RawValueKpi
@@ -19,17 +21,20 @@ object TrufflehogAdapter : KpiAdapter<TrufflehogReportDto, TrufflehogReportDto>(
 
     override fun transformDataToKpi(
         vararg data: TrufflehogReportDto
-    ): Collection<TransformationResult<TrufflehogReportDto>> {
-        return data.mapNotNull {
-            val verifiedSecrets = it.verifiedSecrets
-            if (verifiedSecrets == null) {
-                return@mapNotNull null
+    ): AdapterResult<TrufflehogReportDto> {
+        val transformedData =
+            data.mapNotNull {
+                val verifiedSecrets = it.verifiedSecrets ?: return@mapNotNull null
+                val score = if (verifiedSecrets > 0) 0 else 100
+                TransformationResult.Success.Kpi(
+                    RawValueKpi(score = score, typeId = KpiType.SECRETS.name),
+                    origin = it,
+                )
             }
-            val score = if (verifiedSecrets > 0) 0 else 100
-            TransformationResult.Success.Kpi(
-                RawValueKpi(score = score, typeId = KpiType.SECRETS.name),
-                origin = it,
-            )
-        }
+
+        return AdapterResult(
+            toolInfo = ToolInfo(name = "Trufflehog", description = "Secrets Scanner"),
+            transformationResults = transformedData,
+        )
     }
 }

--- a/adapter/src/test/kotlin/de/fraunhofer/iem/spha/adapter/ToolResultParserTest.kt
+++ b/adapter/src/test/kotlin/de/fraunhofer/iem/spha/adapter/ToolResultParserTest.kt
@@ -77,7 +77,9 @@ class ToolResultParserTest {
         tempOsvDir.toFile().deleteRecursively()
 
         assertTrue(results.isNotEmpty())
-        assertTrue(results.all { it is TransformationResult.Success })
+        results.forEach {
+            assertTrue(it.transformationResults.all { it is TransformationResult.Success<*> })
+        }
     }
 
     @Test

--- a/adapter/src/test/kotlin/de/fraunhofer/iem/spha/adapter/ToolResultParserTest.kt
+++ b/adapter/src/test/kotlin/de/fraunhofer/iem/spha/adapter/ToolResultParserTest.kt
@@ -77,7 +77,7 @@ class ToolResultParserTest {
         tempOsvDir.toFile().deleteRecursively()
 
         assertTrue(results.isNotEmpty())
-        assertTrue(results.all { it is AdapterResult.Success })
+        assertTrue(results.all { it is TransformationResult.Success })
     }
 
     @Test

--- a/adapter/src/test/kotlin/de/fraunhofer/iem/spha/adapter/tools/osv/OsvAdapterTest.kt
+++ b/adapter/src/test/kotlin/de/fraunhofer/iem/spha/adapter/tools/osv/OsvAdapterTest.kt
@@ -9,7 +9,7 @@
 
 package de.fraunhofer.iem.spha.adapter.tools.osv
 
-import de.fraunhofer.iem.spha.adapter.AdapterResult
+import de.fraunhofer.iem.spha.adapter.TransformationResult
 import de.fraunhofer.iem.spha.adapter.ErrorType
 import de.fraunhofer.iem.spha.model.adapter.OsvPackageDto
 import de.fraunhofer.iem.spha.model.adapter.OsvPackageWrapperDto
@@ -63,13 +63,13 @@ class OsvAdapterTest {
             println("[DEBUG_LOG] Total KPIs: ${kpis.size}")
             kpis.forEachIndexed { index, kpi ->
                 println("[DEBUG_LOG] KPI $index: $kpi")
-                if (kpi is AdapterResult.Error) {
+                if (kpi is TransformationResult.Error) {
                     println("[DEBUG_LOG] Error type: ${kpi.type}")
                 }
             }
 
             // Filter out error results
-            val successKpis = kpis.filter { it is AdapterResult.Success }
+            val successKpis = kpis.filter { it is TransformationResult.Success }
 
             // Print debug information
             println("[DEBUG_LOG] Success KPIs: ${successKpis.size}")
@@ -122,7 +122,7 @@ class OsvAdapterTest {
         // Verify the results
         assertEquals(1, results.size)
         val result = results.first()
-        assertTrue(result is AdapterResult.Error)
+        assertTrue(result is TransformationResult.Error)
         assertEquals(ErrorType.DATA_VALIDATION_ERROR, result.type)
     }
 
@@ -168,7 +168,7 @@ class OsvAdapterTest {
         // Verify the results
         assertEquals(1, results.size)
         val result = results.first()
-        assertTrue(result is AdapterResult.Error)
+        assertTrue(result is TransformationResult.Error)
         assertEquals(ErrorType.DATA_VALIDATION_ERROR, result.type)
     }
 
@@ -220,7 +220,7 @@ class OsvAdapterTest {
         // Verify the results
         assertEquals(1, results.size)
         val result = results.first()
-        assertTrue(result is AdapterResult.Error)
+        assertTrue(result is TransformationResult.Error)
         assertEquals(ErrorType.DATA_VALIDATION_ERROR, result.type)
     }
 
@@ -283,7 +283,7 @@ class OsvAdapterTest {
         // Verify the results
         assertEquals(1, results.size)
         val result = results.first()
-        assertTrue(result is AdapterResult.Success)
+        assertTrue(result is TransformationResult.Success)
         val successResult = result
         assertEquals(2, successResult.rawValueKpi.score) // 100 - (9.8 * 10) = 2
     }
@@ -338,7 +338,7 @@ class OsvAdapterTest {
         // Verify the results
         assertEquals(1, results.size)
         val result = results.first()
-        assertTrue(result is AdapterResult.Success)
+        assertTrue(result is TransformationResult.Success)
         val successResult = result
         assertEquals(27, successResult.rawValueKpi.score) // 100 - (7.3 * 10) = 27
         assertEquals(osvVulnerabilityDto, successResult.origin)

--- a/adapter/src/test/kotlin/de/fraunhofer/iem/spha/adapter/tools/osv/OsvAdapterTest.kt
+++ b/adapter/src/test/kotlin/de/fraunhofer/iem/spha/adapter/tools/osv/OsvAdapterTest.kt
@@ -9,8 +9,8 @@
 
 package de.fraunhofer.iem.spha.adapter.tools.osv
 
-import de.fraunhofer.iem.spha.adapter.TransformationResult
 import de.fraunhofer.iem.spha.adapter.ErrorType
+import de.fraunhofer.iem.spha.adapter.TransformationResult
 import de.fraunhofer.iem.spha.model.adapter.OsvPackageDto
 import de.fraunhofer.iem.spha.model.adapter.OsvPackageWrapperDto
 import de.fraunhofer.iem.spha.model.adapter.OsvScannerDto
@@ -54,10 +54,13 @@ class OsvAdapterTest {
 
     @Test
     fun testResultDto() {
-        Files.newInputStream(Path("src/test/resources/osv-scanner.json")).use {
-            val dto = assertDoesNotThrow { OsvAdapter.dtoFromJson(it, OsvScannerDto.serializer()) }
+        Files.newInputStream(Path("src/test/resources/osv-scanner.json")).use { data ->
+            val dto = assertDoesNotThrow {
+                OsvAdapter.dtoFromJson(data, OsvScannerDto.serializer())
+            }
 
-            val kpis = assertDoesNotThrow { OsvAdapter.transformDataToKpi(dto) }
+            val adapterResult = assertDoesNotThrow { OsvAdapter.transformDataToKpi(dto) }
+            val kpis = adapterResult.transformationResults
 
             // Print debug information
             println("[DEBUG_LOG] Total KPIs: ${kpis.size}")
@@ -117,7 +120,8 @@ class OsvAdapterTest {
         val osvScannerDto = OsvScannerDto(results = listOf(osvScannerResultDto))
 
         // Transform the data
-        val results = OsvAdapter.transformDataToKpi(osvScannerDto)
+        val adapterResult = OsvAdapter.transformDataToKpi(osvScannerDto)
+        val results = adapterResult.transformationResults
 
         // Verify the results
         assertEquals(1, results.size)
@@ -163,7 +167,8 @@ class OsvAdapterTest {
         val osvScannerDto = OsvScannerDto(results = listOf(osvScannerResultDto))
 
         // Transform the data
-        val results = OsvAdapter.transformDataToKpi(osvScannerDto)
+        val adapterResult = OsvAdapter.transformDataToKpi(osvScannerDto)
+        val results = adapterResult.transformationResults
 
         // Verify the results
         assertEquals(1, results.size)
@@ -215,7 +220,8 @@ class OsvAdapterTest {
         val osvScannerDto = OsvScannerDto(results = listOf(osvScannerResultDto))
 
         // Transform the data
-        val results = OsvAdapter.transformDataToKpi(osvScannerDto)
+        val adapterResult = OsvAdapter.transformDataToKpi(osvScannerDto)
+        val results = adapterResult.transformationResults
 
         // Verify the results
         assertEquals(1, results.size)
@@ -278,7 +284,8 @@ class OsvAdapterTest {
         val osvScannerDto = OsvScannerDto(results = listOf(osvScannerResultDto))
 
         // Transform the data
-        val results = OsvAdapter.transformDataToKpi(osvScannerDto)
+        val adapterResult = OsvAdapter.transformDataToKpi(osvScannerDto)
+        val results = adapterResult.transformationResults
 
         // Verify the results
         assertEquals(1, results.size)
@@ -333,14 +340,14 @@ class OsvAdapterTest {
         val osvScannerDto = OsvScannerDto(results = listOf(osvScannerResultDto))
 
         // Transform the data
-        val results = OsvAdapter.transformDataToKpi(osvScannerDto)
+        val adapterResult = OsvAdapter.transformDataToKpi(osvScannerDto)
+        val results = adapterResult.transformationResults
 
         // Verify the results
         assertEquals(1, results.size)
         val result = results.first()
         assertTrue(result is TransformationResult.Success)
-        val successResult = result
-        assertEquals(27, successResult.rawValueKpi.score) // 100 - (7.3 * 10) = 27
-        assertEquals(osvVulnerabilityDto, successResult.origin)
+        assertEquals(27, result.rawValueKpi.score) // 100 - (7.3 * 10) = 27
+        assertEquals(osvVulnerabilityDto, result.origin)
     }
 }

--- a/adapter/src/test/kotlin/de/fraunhofer/iem/spha/adapter/tools/tlc/TlcAdapterTest.kt
+++ b/adapter/src/test/kotlin/de/fraunhofer/iem/spha/adapter/tools/tlc/TlcAdapterTest.kt
@@ -9,7 +9,7 @@
 
 package de.fraunhofer.iem.spha.adapter.tools.tlc
 
-import de.fraunhofer.iem.spha.adapter.AdapterResult
+import de.fraunhofer.iem.spha.adapter.TransformationResult
 import de.fraunhofer.iem.spha.model.adapter.Component
 import de.fraunhofer.iem.spha.model.adapter.ComponentLag
 import de.fraunhofer.iem.spha.model.adapter.TechnicalLag
@@ -106,9 +106,9 @@ class TlcAdapterTest {
         assertEquals(expectedTotal, kpis.size)
 
         // All results should be Success.Kpi
-        kpis.forEach { assertTrue(it is AdapterResult.Success.Kpi<*>) }
+        kpis.forEach { assertTrue(it is TransformationResult.Success.Kpi<*>) }
 
-        val kpisTyped = kpis.filterIsInstance<AdapterResult.Success.Kpi<*>>()
+        val kpisTyped = kpis.filterIsInstance<TransformationResult.Success.Kpi<*>>()
 
         // Verify the 4 base KPIs and their scores equal rounded-down highestLibdays
         fun Double.toScore() = this.toInt()
@@ -172,7 +172,7 @@ class TlcAdapterTest {
         assertEquals(expected, kpis.size)
 
         // All results should be Success.Kpi
-        kpis.forEach { assertTrue(it is AdapterResult.Success.Kpi<*>) }
+        kpis.forEach { assertTrue(it is TransformationResult.Success.Kpi<*>) }
     }
 
     @Test
@@ -192,7 +192,7 @@ class TlcAdapterTest {
             val kpis = assertDoesNotThrow { TlcAdapter.transformDataToKpi(tlcDto) }
 
             // All results should be Success.Kpi
-            kpis.forEach { assertTrue(it is AdapterResult.Success.Kpi<*>) }
+            kpis.forEach { assertTrue(it is TransformationResult.Success.Kpi<*>) }
 
             // Should have at least the base KPIs + component KPIs
             val expectedMinimumKpis =

--- a/adapter/src/test/kotlin/de/fraunhofer/iem/spha/adapter/tools/tlc/TlcAdapterTest.kt
+++ b/adapter/src/test/kotlin/de/fraunhofer/iem/spha/adapter/tools/tlc/TlcAdapterTest.kt
@@ -95,7 +95,8 @@ class TlcAdapterTest {
     fun testTransformDataToKpi() {
         val tlcDto = sampleDto()
 
-        val kpis = assertDoesNotThrow { TlcAdapter.transformDataToKpi(tlcDto) }
+        val adapterResult = assertDoesNotThrow { TlcAdapter.transformDataToKpi(tlcDto) }
+        val kpis = adapterResult.transformationResults
 
         val componentCount =
             tlcDto.transitiveOptional.components.size +
@@ -155,7 +156,8 @@ class TlcAdapterTest {
         val tlcDto1 = sampleDto()
         val tlcDto2 = sampleDto()
 
-        val kpis = assertDoesNotThrow { TlcAdapter.transformDataToKpi(tlcDto1, tlcDto2) }
+        val adapterResult = assertDoesNotThrow { TlcAdapter.transformDataToKpi(tlcDto1, tlcDto2) }
+        val kpis = adapterResult.transformationResults
 
         val componentCount1 =
             tlcDto1.transitiveOptional.components.size +
@@ -189,7 +191,8 @@ class TlcAdapterTest {
             )
 
             // Test transformation to KPIs
-            val kpis = assertDoesNotThrow { TlcAdapter.transformDataToKpi(tlcDto) }
+            val adapterResult = assertDoesNotThrow { TlcAdapter.transformDataToKpi(tlcDto) }
+            val kpis = adapterResult.transformationResults
 
             // All results should be Success.Kpi
             kpis.forEach { assertTrue(it is TransformationResult.Success.Kpi<*>) }

--- a/adapter/src/test/kotlin/de/fraunhofer/iem/spha/adapter/tools/trivy/TrivyAdapterTest.kt
+++ b/adapter/src/test/kotlin/de/fraunhofer/iem/spha/adapter/tools/trivy/TrivyAdapterTest.kt
@@ -9,7 +9,7 @@
 
 package de.fraunhofer.iem.spha.adapter.tools.trivy
 
-import de.fraunhofer.iem.spha.adapter.AdapterResult
+import de.fraunhofer.iem.spha.adapter.TransformationResult
 import de.fraunhofer.iem.spha.adapter.ErrorType
 import de.fraunhofer.iem.spha.model.adapter.TrivyDtoV2
 import de.fraunhofer.iem.spha.model.adapter.TrivyResult
@@ -120,11 +120,11 @@ class TrivyAdapterTest {
         val result = adapterResults.first()
 
         // The result might be an AdapterResult.Error, so we'll check both cases
-        if (result is AdapterResult.Success) {
+        if (result is TransformationResult.Success) {
             assertEquals(40, result.rawValueKpi.score)
         } else {
             // If it's an error, we'll just check that it's an AdapterResult.Error
-            assert(result is AdapterResult.Error)
+            assert(result is TransformationResult.Error)
         }
     }
 
@@ -155,7 +155,7 @@ class TrivyAdapterTest {
 
         assertEquals(1, adapterResults.size)
         val result = adapterResults.first()
-        assertTrue(result is AdapterResult.Error)
+        assertTrue(result is TransformationResult.Error)
         assertEquals(ErrorType.DATA_VALIDATION_ERROR, result.type)
     }
 
@@ -186,8 +186,8 @@ class TrivyAdapterTest {
 
         assertEquals(1, adapterResults.size)
         val result = adapterResults.first()
-        assertTrue(result is AdapterResult.Success)
-        assertEquals(100, (result as AdapterResult.Success.Kpi).rawValueKpi.score)
+        assertTrue(result is TransformationResult.Success)
+        assertEquals(100, (result as TransformationResult.Success.Kpi).rawValueKpi.score)
     }
 
     @Test
@@ -234,8 +234,8 @@ class TrivyAdapterTest {
 
         assertEquals(1, adapterResults.size)
         val result = adapterResults.first()
-        assertTrue(result is AdapterResult.Success)
-        assertEquals(25, (result as AdapterResult.Success.Kpi).rawValueKpi.score)
+        assertTrue(result is TransformationResult.Success)
+        assertEquals(25, (result as TransformationResult.Success.Kpi).rawValueKpi.score)
     }
 
     @Test
@@ -282,8 +282,8 @@ class TrivyAdapterTest {
 
         assertEquals(1, adapterResults.size)
         val result = adapterResults.first()
-        assertTrue(result is AdapterResult.Success)
-        assertEquals(15, (result as AdapterResult.Success.Kpi).rawValueKpi.score)
+        assertTrue(result is TransformationResult.Success)
+        assertEquals(15, (result as TransformationResult.Success.Kpi).rawValueKpi.score)
     }
 
     @OptIn(ExperimentalSerializationApi::class)
@@ -335,8 +335,8 @@ class TrivyAdapterTest {
 
         assertEquals(1, adapterResults.size)
         val result = adapterResults.first()
-        assertTrue(result is AdapterResult.Success)
-        assertEquals(100, (result as AdapterResult.Success.Kpi).rawValueKpi.score)
+        assertTrue(result is TransformationResult.Success)
+        assertEquals(100, (result as TransformationResult.Success.Kpi).rawValueKpi.score)
     }
 
     @Test
@@ -403,8 +403,8 @@ class TrivyAdapterTest {
 
         assertEquals(1, adapterResults.size)
         val result = adapterResults.first()
-        assertTrue(result is AdapterResult.Success)
-        assertEquals(20, (result as AdapterResult.Success.Kpi).rawValueKpi.score)
+        assertTrue(result is TransformationResult.Success)
+        assertEquals(20, (result as TransformationResult.Success.Kpi).rawValueKpi.score)
     }
 
     @Test
@@ -451,7 +451,7 @@ class TrivyAdapterTest {
 
         assertEquals(1, adapterResults.size)
         val result = adapterResults.first()
-        assertTrue(result is AdapterResult.Error)
+        assertTrue(result is TransformationResult.Error)
         assertEquals(ErrorType.DATA_VALIDATION_ERROR, result.type)
     }
 
@@ -525,14 +525,14 @@ class TrivyAdapterTest {
 
         // Check first vulnerability
         val result1 = adapterResults.first()
-        assertTrue(result1 is AdapterResult.Success)
-        assertEquals(50, (result1 as AdapterResult.Success.Kpi).rawValueKpi.score)
+        assertTrue(result1 is TransformationResult.Success)
+        assertEquals(50, (result1 as TransformationResult.Success.Kpi).rawValueKpi.score)
         assertEquals("VULN-1", result1.origin.vulnerabilityID)
 
         // Check second vulnerability
         val result2 = adapterResults.last()
-        assertTrue(result2 is AdapterResult.Success)
-        assertEquals(20, (result2 as AdapterResult.Success.Kpi).rawValueKpi.score)
+        assertTrue(result2 is TransformationResult.Success)
+        assertEquals(20, (result2 as TransformationResult.Success.Kpi).rawValueKpi.score)
         assertEquals("VULN-2", result2.origin.vulnerabilityID)
     }
 }

--- a/adapter/src/test/kotlin/de/fraunhofer/iem/spha/adapter/tools/trivy/TrivyAdapterTest.kt
+++ b/adapter/src/test/kotlin/de/fraunhofer/iem/spha/adapter/tools/trivy/TrivyAdapterTest.kt
@@ -9,8 +9,8 @@
 
 package de.fraunhofer.iem.spha.adapter.tools.trivy
 
-import de.fraunhofer.iem.spha.adapter.TransformationResult
 import de.fraunhofer.iem.spha.adapter.ErrorType
+import de.fraunhofer.iem.spha.adapter.TransformationResult
 import de.fraunhofer.iem.spha.model.adapter.TrivyDtoV2
 import de.fraunhofer.iem.spha.model.adapter.TrivyResult
 import de.fraunhofer.iem.spha.model.adapter.TrivyVulnerabilityDto
@@ -114,7 +114,8 @@ class TrivyAdapterTest {
                 schemaVersion = 2,
             )
 
-        val adapterResults = TrivyAdapter.transformDataToKpi(trivyV2Dto)
+        val adapterResult = TrivyAdapter.transformDataToKpi(trivyV2Dto)
+        val adapterResults = adapterResult.transformationResults
 
         assertEquals(1, adapterResults.size)
         val result = adapterResults.first()
@@ -151,7 +152,8 @@ class TrivyAdapterTest {
                 schemaVersion = 2,
             )
 
-        val adapterResults = TrivyAdapter.transformDataToKpi(trivyV2Dto)
+        val adapterResult = TrivyAdapter.transformDataToKpi(trivyV2Dto)
+        val adapterResults = adapterResult.transformationResults
 
         assertEquals(1, adapterResults.size)
         val result = adapterResults.first()
@@ -182,7 +184,8 @@ class TrivyAdapterTest {
                 schemaVersion = 2,
             )
 
-        val adapterResults = TrivyAdapter.transformDataToKpi(trivyV2Dto)
+        val adapterResult = TrivyAdapter.transformDataToKpi(trivyV2Dto)
+        val adapterResults = adapterResult.transformationResults
 
         assertEquals(1, adapterResults.size)
         val result = adapterResults.first()
@@ -230,7 +233,8 @@ class TrivyAdapterTest {
                 schemaVersion = 2,
             )
 
-        val adapterResults = TrivyAdapter.transformDataToKpi(trivyV2Dto)
+        val adapterResult = TrivyAdapter.transformDataToKpi(trivyV2Dto)
+        val adapterResults = adapterResult.transformationResults
 
         assertEquals(1, adapterResults.size)
         val result = adapterResults.first()
@@ -278,7 +282,8 @@ class TrivyAdapterTest {
                 schemaVersion = 2,
             )
 
-        val adapterResults = TrivyAdapter.transformDataToKpi(trivyV2Dto)
+        val adapterResult = TrivyAdapter.transformDataToKpi(trivyV2Dto)
+        val adapterResults = adapterResult.transformationResults
 
         assertEquals(1, adapterResults.size)
         val result = adapterResults.first()
@@ -331,7 +336,8 @@ class TrivyAdapterTest {
                 schemaVersion = 2,
             )
 
-        val adapterResults = TrivyAdapter.transformDataToKpi(trivyV2Dto)
+        val adapterResult = TrivyAdapter.transformDataToKpi(trivyV2Dto)
+        val adapterResults = adapterResult.transformationResults
 
         assertEquals(1, adapterResults.size)
         val result = adapterResults.first()
@@ -399,7 +405,8 @@ class TrivyAdapterTest {
                 schemaVersion = 2,
             )
 
-        val adapterResults = TrivyAdapter.transformDataToKpi(trivyV2Dto)
+        val adapterResult = TrivyAdapter.transformDataToKpi(trivyV2Dto)
+        val adapterResults = adapterResult.transformationResults
 
         assertEquals(1, adapterResults.size)
         val result = adapterResults.first()
@@ -447,7 +454,8 @@ class TrivyAdapterTest {
                 schemaVersion = 2,
             )
 
-        val adapterResults = TrivyAdapter.transformDataToKpi(trivyV2Dto)
+        val adapterResult = TrivyAdapter.transformDataToKpi(trivyV2Dto)
+        val adapterResults = adapterResult.transformationResults
 
         assertEquals(1, adapterResults.size)
         val result = adapterResults.first()
@@ -519,7 +527,8 @@ class TrivyAdapterTest {
                 schemaVersion = 2,
             )
 
-        val adapterResults = TrivyAdapter.transformDataToKpi(trivyV2Dto)
+        val adapterResult = TrivyAdapter.transformDataToKpi(trivyV2Dto)
+        val adapterResults = adapterResult.transformationResults
 
         assertEquals(2, adapterResults.size)
 

--- a/adapter/src/test/kotlin/de/fraunhofer/iem/spha/adapter/tools/trufflehog/TrufflehogAdapterTest.kt
+++ b/adapter/src/test/kotlin/de/fraunhofer/iem/spha/adapter/tools/trufflehog/TrufflehogAdapterTest.kt
@@ -63,7 +63,8 @@ class TrufflehogAdapterTest {
                 TrufflehogAdapter.dtoFromJson(it, TrufflehogReportDto.serializer())
             }
 
-            val kpis = assertDoesNotThrow { TrufflehogAdapter.transformDataToKpi(dto) }
+            val adapterResult = assertDoesNotThrow { TrufflehogAdapter.transformDataToKpi(dto) }
+            val kpis = adapterResult.transformationResults
 
             assertEquals(1, kpis.size)
 
@@ -80,7 +81,8 @@ class TrufflehogAdapterTest {
                 TrufflehogAdapter.dtoFromJson(it, TrufflehogReportDto.serializer())
             }
 
-            val kpis = assertDoesNotThrow { TrufflehogAdapter.transformDataToKpi(dto) }
+            val adapterResult = assertDoesNotThrow { TrufflehogAdapter.transformDataToKpi(dto) }
+            val kpis = adapterResult.transformationResults
 
             assertEquals(1, kpis.size)
 

--- a/adapter/src/test/kotlin/de/fraunhofer/iem/spha/adapter/tools/trufflehog/TrufflehogAdapterTest.kt
+++ b/adapter/src/test/kotlin/de/fraunhofer/iem/spha/adapter/tools/trufflehog/TrufflehogAdapterTest.kt
@@ -9,7 +9,7 @@
 
 package de.fraunhofer.iem.spha.adapter.tools.trufflehog
 
-import de.fraunhofer.iem.spha.adapter.AdapterResult
+import de.fraunhofer.iem.spha.adapter.TransformationResult
 import de.fraunhofer.iem.spha.model.adapter.TrufflehogReportDto
 import java.nio.file.Files
 import kotlin.io.path.Path
@@ -67,9 +67,9 @@ class TrufflehogAdapterTest {
 
             assertEquals(1, kpis.size)
 
-            kpis.forEach { assert(it is AdapterResult.Success) }
+            kpis.forEach { assert(it is TransformationResult.Success) }
 
-            assertEquals(100, (kpis.first() as AdapterResult.Success.Kpi).rawValueKpi.score)
+            assertEquals(100, (kpis.first() as TransformationResult.Success.Kpi).rawValueKpi.score)
         }
     }
 
@@ -84,9 +84,9 @@ class TrufflehogAdapterTest {
 
             assertEquals(1, kpis.size)
 
-            kpis.forEach { assert(it is AdapterResult.Success) }
+            kpis.forEach { assert(it is TransformationResult.Success) }
 
-            assertEquals(0, (kpis.first() as AdapterResult.Success.Kpi).rawValueKpi.score)
+            assertEquals(0, (kpis.first() as TransformationResult.Success.Kpi).rawValueKpi.score)
         }
     }
 }


### PR DESCRIPTION
---

### Description of the changes

This pull request introduces several improvements and changes to the adapter processing pipeline:

- Added serialization support to `KpiAdapter` data models.
- Updated `ToolResultParser.kt` to support the new result format.
- Modified adapter tests to incorporate new changes and ensure compatibility.
- **Breaking change:** Updated adapter results to optionally include `toolInfo`.
- Renamed `AdapterResult` to `TransformationResult` and introduced a new data class for `AdapterResult` with an additional field for tool information.

### Breaking Changes
- `AdapterResult` is renamed to `TransformationResult`, and the existing structure is updated. 
